### PR TITLE
feat: add internationalization (i18n) support

### DIFF
--- a/app/chrome-extension/_locales/en/messages.json
+++ b/app/chrome-extension/_locales/en/messages.json
@@ -1,0 +1,446 @@
+{
+  "extensionName": {
+    "message": "chrome-mcp-server",
+    "description": "Extension name"
+  },
+  "extensionDescription": {
+    "message": "Exposes browser capabilities with your own chrome",
+    "description": "Extension description"
+  },
+  "nativeServerConfigLabel": {
+    "message": "Native Server Configuration",
+    "description": "Main section header for native server settings"
+  },
+  "semanticEngineLabel": {
+    "message": "Semantic Engine",
+    "description": "Main section header for semantic engine"
+  },
+  "embeddingModelLabel": {
+    "message": "Embedding Model",
+    "description": "Main section header for model selection"
+  },
+  "indexDataManagementLabel": {
+    "message": "Index Data Management",
+    "description": "Main section header for data management"
+  },
+  "modelCacheManagementLabel": {
+    "message": "Model Cache Management",
+    "description": "Main section header for cache management"
+  },
+  "statusLabel": {
+    "message": "Status",
+    "description": "Generic status label"
+  },
+  "runningStatusLabel": {
+    "message": "Running Status",
+    "description": "Server running status label"
+  },
+  "connectionStatusLabel": {
+    "message": "Connection Status",
+    "description": "Connection status label"
+  },
+  "lastUpdatedLabel": {
+    "message": "Last Updated:",
+    "description": "Last updated timestamp label"
+  },
+  "connectButton": {
+    "message": "Connect",
+    "description": "Connect button text"
+  },
+  "disconnectButton": {
+    "message": "Disconnect",
+    "description": "Disconnect button text"
+  },
+  "connectingStatus": {
+    "message": "Connecting...",
+    "description": "Connecting status message"
+  },
+  "connectedStatus": {
+    "message": "Connected",
+    "description": "Connected status message"
+  },
+  "disconnectedStatus": {
+    "message": "Disconnected",
+    "description": "Disconnected status message"
+  },
+  "detectingStatus": {
+    "message": "Detecting...",
+    "description": "Detecting status message"
+  },
+  "serviceRunningStatus": {
+    "message": "Service Running (Port: $PORT$)",
+    "description": "Service running with port number",
+    "placeholders": {
+      "port": {
+        "content": "$1",
+        "example": "12306"
+      }
+    }
+  },
+  "serviceNotConnectedStatus": {
+    "message": "Service Not Connected",
+    "description": "Service not connected status"
+  },
+  "connectedServiceNotStartedStatus": {
+    "message": "Connected, Service Not Started",
+    "description": "Connected but service not started status"
+  },
+  "mcpServerConfigLabel": {
+    "message": "MCP Server Configuration",
+    "description": "MCP server configuration section label"
+  },
+  "connectionPortLabel": {
+    "message": "Connection Port",
+    "description": "Connection port input label"
+  },
+  "refreshStatusButton": {
+    "message": "Refresh Status",
+    "description": "Refresh status button tooltip"
+  },
+  "copyConfigButton": {
+    "message": "Copy Configuration",
+    "description": "Copy configuration button text"
+  },
+  "retryButton": {
+    "message": "Retry",
+    "description": "Retry button text"
+  },
+  "cancelButton": {
+    "message": "Cancel",
+    "description": "Cancel button text"
+  },
+  "confirmButton": {
+    "message": "Confirm",
+    "description": "Confirm button text"
+  },
+  "saveButton": {
+    "message": "Save",
+    "description": "Save button text"
+  },
+  "closeButton": {
+    "message": "Close",
+    "description": "Close button text"
+  },
+  "resetButton": {
+    "message": "Reset",
+    "description": "Reset button text"
+  },
+  "initializingStatus": {
+    "message": "Initializing...",
+    "description": "Initializing progress message"
+  },
+  "processingStatus": {
+    "message": "Processing...",
+    "description": "Processing progress message"
+  },
+  "loadingStatus": {
+    "message": "Loading...",
+    "description": "Loading progress message"
+  },
+  "clearingStatus": {
+    "message": "Clearing...",
+    "description": "Clearing progress message"
+  },
+  "cleaningStatus": {
+    "message": "Cleaning...",
+    "description": "Cleaning progress message"
+  },
+  "downloadingStatus": {
+    "message": "Downloading...",
+    "description": "Downloading progress message"
+  },
+  "semanticEngineReadyStatus": {
+    "message": "Semantic Engine Ready",
+    "description": "Semantic engine ready status"
+  },
+  "semanticEngineInitializingStatus": {
+    "message": "Semantic Engine Initializing...",
+    "description": "Semantic engine initializing status"
+  },
+  "semanticEngineInitFailedStatus": {
+    "message": "Semantic Engine Initialization Failed",
+    "description": "Semantic engine initialization failed status"
+  },
+  "semanticEngineNotInitStatus": {
+    "message": "Semantic Engine Not Initialized",
+    "description": "Semantic engine not initialized status"
+  },
+  "initSemanticEngineButton": {
+    "message": "Initialize Semantic Engine",
+    "description": "Initialize semantic engine button text"
+  },
+  "reinitializeButton": {
+    "message": "Reinitialize",
+    "description": "Reinitialize button text"
+  },
+  "downloadingModelStatus": {
+    "message": "Downloading Model... $PROGRESS$%",
+    "description": "Model download progress with percentage",
+    "placeholders": {
+      "progress": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "switchingModelStatus": {
+    "message": "Switching Model...",
+    "description": "Model switching progress message"
+  },
+  "modelLoadedStatus": {
+    "message": "Model Loaded",
+    "description": "Model successfully loaded status"
+  },
+  "modelFailedStatus": {
+    "message": "Model Failed to Load",
+    "description": "Model failed to load status"
+  },
+  "lightweightModelDescription": {
+    "message": "Lightweight Multilingual Model",
+    "description": "Description for lightweight model option"
+  },
+  "betterThanSmallDescription": {
+    "message": "Slightly larger than e5-small, but better performance",
+    "description": "Description for medium model option"
+  },
+  "multilingualModelDescription": {
+    "message": "Multilingual Semantic Model",
+    "description": "Description for multilingual model option"
+  },
+  "fastPerformance": {
+    "message": "Fast",
+    "description": "Fast performance indicator"
+  },
+  "balancedPerformance": {
+    "message": "Balanced",
+    "description": "Balanced performance indicator"
+  },
+  "accuratePerformance": {
+    "message": "Accurate",
+    "description": "Accurate performance indicator"
+  },
+  "networkErrorMessage": {
+    "message": "Network connection error, please check network and retry",
+    "description": "Network connection error message"
+  },
+  "modelCorruptedErrorMessage": {
+    "message": "Model file corrupted or incomplete, please retry download",
+    "description": "Model corruption error message"
+  },
+  "unknownErrorMessage": {
+    "message": "Unknown error, please check if your network can access HuggingFace",
+    "description": "Unknown error fallback message"
+  },
+  "permissionDeniedErrorMessage": {
+    "message": "Permission denied",
+    "description": "Permission denied error message"
+  },
+  "timeoutErrorMessage": {
+    "message": "Operation timed out",
+    "description": "Timeout error message"
+  },
+  "indexedPagesLabel": {
+    "message": "Indexed Pages",
+    "description": "Number of indexed pages label"
+  },
+  "indexSizeLabel": {
+    "message": "Index Size",
+    "description": "Index size label"
+  },
+  "activeTabsLabel": {
+    "message": "Active Tabs",
+    "description": "Number of active tabs label"
+  },
+  "vectorDocumentsLabel": {
+    "message": "Vector Documents",
+    "description": "Number of vector documents label"
+  },
+  "cacheSizeLabel": {
+    "message": "Cache Size",
+    "description": "Cache size label"
+  },
+  "cacheEntriesLabel": {
+    "message": "Cache Entries",
+    "description": "Number of cache entries label"
+  },
+  "clearAllDataButton": {
+    "message": "Clear All Data",
+    "description": "Clear all data button text"
+  },
+  "clearAllCacheButton": {
+    "message": "Clear All Cache",
+    "description": "Clear all cache button text"
+  },
+  "cleanExpiredCacheButton": {
+    "message": "Clean Expired Cache",
+    "description": "Clean expired cache button text"
+  },
+  "exportDataButton": {
+    "message": "Export Data",
+    "description": "Export data button text"
+  },
+  "importDataButton": {
+    "message": "Import Data",
+    "description": "Import data button text"
+  },
+  "confirmClearDataTitle": {
+    "message": "Confirm Clear Data",
+    "description": "Clear data confirmation dialog title"
+  },
+  "settingsTitle": {
+    "message": "Settings",
+    "description": "Settings dialog title"
+  },
+  "aboutTitle": {
+    "message": "About",
+    "description": "About dialog title"
+  },
+  "helpTitle": {
+    "message": "Help",
+    "description": "Help dialog title"
+  },
+  "clearDataWarningMessage": {
+    "message": "This operation will clear all indexed webpage content and vector data, including:",
+    "description": "Clear data warning message"
+  },
+  "clearDataList1": {
+    "message": "All webpage text content index",
+    "description": "First item in clear data list"
+  },
+  "clearDataList2": {
+    "message": "Vector embedding data",
+    "description": "Second item in clear data list"
+  },
+  "clearDataList3": {
+    "message": "Search history and cache",
+    "description": "Third item in clear data list"
+  },
+  "clearDataIrreversibleWarning": {
+    "message": "This operation is irreversible! After clearing, you need to browse webpages again to rebuild the index.",
+    "description": "Irreversible operation warning"
+  },
+  "confirmClearButton": {
+    "message": "Confirm Clear",
+    "description": "Confirm clear action button"
+  },
+  "cacheDetailsLabel": {
+    "message": "Cache Details",
+    "description": "Cache details section label"
+  },
+  "noCacheDataMessage": {
+    "message": "No cache data",
+    "description": "No cache data available message"
+  },
+  "loadingCacheInfoStatus": {
+    "message": "Loading cache information...",
+    "description": "Loading cache information status"
+  },
+  "processingCacheStatus": {
+    "message": "Processing cache...",
+    "description": "Processing cache status"
+  },
+  "expiredLabel": {
+    "message": "Expired",
+    "description": "Expired item label"
+  },
+  "bookmarksBarLabel": {
+    "message": "Bookmarks Bar",
+    "description": "Bookmarks bar folder name"
+  },
+  "newTabLabel": {
+    "message": "New Tab",
+    "description": "New tab label"
+  },
+  "currentPageLabel": {
+    "message": "Current Page",
+    "description": "Current page label"
+  },
+  "menuLabel": {
+    "message": "Menu",
+    "description": "Menu accessibility label"
+  },
+  "navigationLabel": {
+    "message": "Navigation",
+    "description": "Navigation accessibility label"
+  },
+  "mainContentLabel": {
+    "message": "Main Content",
+    "description": "Main content accessibility label"
+  },
+  "languageSelectorLabel": {
+    "message": "Language",
+    "description": "Language selector label"
+  },
+  "themeLabel": {
+    "message": "Theme",
+    "description": "Theme selector label"
+  },
+  "lightTheme": {
+    "message": "Light",
+    "description": "Light theme option"
+  },
+  "darkTheme": {
+    "message": "Dark",
+    "description": "Dark theme option"
+  },
+  "autoTheme": {
+    "message": "Auto",
+    "description": "Auto theme option"
+  },
+  "advancedSettingsLabel": {
+    "message": "Advanced Settings",
+    "description": "Advanced settings section label"
+  },
+  "debugModeLabel": {
+    "message": "Debug Mode",
+    "description": "Debug mode toggle label"
+  },
+  "verboseLoggingLabel": {
+    "message": "Verbose Logging",
+    "description": "Verbose logging toggle label"
+  },
+  "successNotification": {
+    "message": "Operation completed successfully",
+    "description": "Generic success notification"
+  },
+  "warningNotification": {
+    "message": "Warning: Please review before proceeding",
+    "description": "Generic warning notification"
+  },
+  "infoNotification": {
+    "message": "Information",
+    "description": "Generic info notification"
+  },
+  "configCopiedNotification": {
+    "message": "Configuration copied to clipboard",
+    "description": "Configuration copied success message"
+  },
+  "dataClearedNotification": {
+    "message": "Data cleared successfully",
+    "description": "Data cleared success message"
+  },
+  "bytesUnit": {
+    "message": "bytes",
+    "description": "Bytes unit"
+  },
+  "kilobytesUnit": {
+    "message": "KB",
+    "description": "Kilobytes unit"
+  },
+  "megabytesUnit": {
+    "message": "MB",
+    "description": "Megabytes unit"
+  },
+  "gigabytesUnit": {
+    "message": "GB",
+    "description": "Gigabytes unit"
+  },
+  "itemsUnit": {
+    "message": "items",
+    "description": "Items count unit"
+  },
+  "pagesUnit": {
+    "message": "pages",
+    "description": "Pages count unit"
+  }
+}

--- a/app/chrome-extension/_locales/zh_CN/messages.json
+++ b/app/chrome-extension/_locales/zh_CN/messages.json
@@ -1,0 +1,446 @@
+{
+  "extensionName": {
+    "message": "chrome-mcp-server",
+    "description": "扩展名称"
+  },
+  "extensionDescription": {
+    "message": "使用你自己的 Chrome 浏览器暴露浏览器功能",
+    "description": "扩展描述"
+  },
+  "nativeServerConfigLabel": {
+    "message": "Native Server 配置",
+    "description": "本地服务器设置的主要节标题"
+  },
+  "semanticEngineLabel": {
+    "message": "语义引擎",
+    "description": "语义引擎的主要节标题"
+  },
+  "embeddingModelLabel": {
+    "message": "Embedding模型",
+    "description": "模型选择的主要节标题"
+  },
+  "indexDataManagementLabel": {
+    "message": "索引数据管理",
+    "description": "数据管理的主要节标题"
+  },
+  "modelCacheManagementLabel": {
+    "message": "模型缓存管理",
+    "description": "缓存管理的主要节标题"
+  },
+  "statusLabel": {
+    "message": "状态",
+    "description": "通用状态标签"
+  },
+  "runningStatusLabel": {
+    "message": "运行状态",
+    "description": "服务器运行状态标签"
+  },
+  "connectionStatusLabel": {
+    "message": "连接状态",
+    "description": "连接状态标签"
+  },
+  "lastUpdatedLabel": {
+    "message": "最后更新:",
+    "description": "最后更新时间戳标签"
+  },
+  "connectButton": {
+    "message": "连接",
+    "description": "连接按钮文本"
+  },
+  "disconnectButton": {
+    "message": "断开",
+    "description": "断开连接按钮文本"
+  },
+  "connectingStatus": {
+    "message": "连接中...",
+    "description": "连接状态消息"
+  },
+  "connectedStatus": {
+    "message": "已连接",
+    "description": "已连接状态消息"
+  },
+  "disconnectedStatus": {
+    "message": "已断开",
+    "description": "已断开状态消息"
+  },
+  "detectingStatus": {
+    "message": "检测中...",
+    "description": "检测状态消息"
+  },
+  "serviceRunningStatus": {
+    "message": "服务运行中 (端口: $PORT$)",
+    "description": "带端口号的服务运行状态",
+    "placeholders": {
+      "port": {
+        "content": "$1",
+        "example": "12306"
+      }
+    }
+  },
+  "serviceNotConnectedStatus": {
+    "message": "服务未连接",
+    "description": "服务未连接状态"
+  },
+  "connectedServiceNotStartedStatus": {
+    "message": "已连接，服务未启动",
+    "description": "已连接但服务未启动状态"
+  },
+  "mcpServerConfigLabel": {
+    "message": "MCP 服务器配置",
+    "description": "MCP 服务器配置节标签"
+  },
+  "connectionPortLabel": {
+    "message": "连接端口",
+    "description": "连接端口输入标签"
+  },
+  "refreshStatusButton": {
+    "message": "刷新状态",
+    "description": "刷新状态按钮提示"
+  },
+  "copyConfigButton": {
+    "message": "复制配置",
+    "description": "复制配置按钮文本"
+  },
+  "retryButton": {
+    "message": "重试",
+    "description": "重试按钮文本"
+  },
+  "cancelButton": {
+    "message": "取消",
+    "description": "取消按钮文本"
+  },
+  "confirmButton": {
+    "message": "确认",
+    "description": "确认按钮文本"
+  },
+  "saveButton": {
+    "message": "保存",
+    "description": "保存按钮文本"
+  },
+  "closeButton": {
+    "message": "关闭",
+    "description": "关闭按钮文本"
+  },
+  "resetButton": {
+    "message": "重置",
+    "description": "重置按钮文本"
+  },
+  "initializingStatus": {
+    "message": "初始化中...",
+    "description": "初始化进度消息"
+  },
+  "processingStatus": {
+    "message": "处理中...",
+    "description": "处理进度消息"
+  },
+  "loadingStatus": {
+    "message": "加载中...",
+    "description": "加载进度消息"
+  },
+  "clearingStatus": {
+    "message": "清空中...",
+    "description": "清空进度消息"
+  },
+  "cleaningStatus": {
+    "message": "清理中...",
+    "description": "清理进度消息"
+  },
+  "downloadingStatus": {
+    "message": "下载中...",
+    "description": "下载进度消息"
+  },
+  "semanticEngineReadyStatus": {
+    "message": "语义引擎已就绪",
+    "description": "语义引擎就绪状态"
+  },
+  "semanticEngineInitializingStatus": {
+    "message": "语义引擎初始化中...",
+    "description": "语义引擎初始化状态"
+  },
+  "semanticEngineInitFailedStatus": {
+    "message": "语义引擎初始化失败",
+    "description": "语义引擎初始化失败状态"
+  },
+  "semanticEngineNotInitStatus": {
+    "message": "语义引擎未初始化",
+    "description": "语义引擎未初始化状态"
+  },
+  "initSemanticEngineButton": {
+    "message": "初始化语义引擎",
+    "description": "初始化语义引擎按钮文本"
+  },
+  "reinitializeButton": {
+    "message": "重新初始化",
+    "description": "重新初始化按钮文本"
+  },
+  "downloadingModelStatus": {
+    "message": "下载模型中... $PROGRESS$%",
+    "description": "带百分比的模型下载进度",
+    "placeholders": {
+      "progress": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "switchingModelStatus": {
+    "message": "切换模型中...",
+    "description": "模型切换进度消息"
+  },
+  "modelLoadedStatus": {
+    "message": "模型已加载",
+    "description": "模型成功加载状态"
+  },
+  "modelFailedStatus": {
+    "message": "模型加载失败",
+    "description": "模型加载失败状态"
+  },
+  "lightweightModelDescription": {
+    "message": "轻量级多语言模型",
+    "description": "轻量级模型选项的描述"
+  },
+  "betterThanSmallDescription": {
+    "message": "比e5-small稍大，但效果更好",
+    "description": "中等模型选项的描述"
+  },
+  "multilingualModelDescription": {
+    "message": "多语言语义模型",
+    "description": "多语言模型选项的描述"
+  },
+  "fastPerformance": {
+    "message": "快速",
+    "description": "快速性能指示器"
+  },
+  "balancedPerformance": {
+    "message": "平衡",
+    "description": "平衡性能指示器"
+  },
+  "accuratePerformance": {
+    "message": "精确",
+    "description": "精确性能指示器"
+  },
+  "networkErrorMessage": {
+    "message": "网络连接错误，请检查网络连接后重试",
+    "description": "网络连接错误消息"
+  },
+  "modelCorruptedErrorMessage": {
+    "message": "模型文件损坏或不完整，请重试下载",
+    "description": "模型损坏错误消息"
+  },
+  "unknownErrorMessage": {
+    "message": "未知错误，请检查你的网络是否可以访问HuggingFace",
+    "description": "未知错误回退消息"
+  },
+  "permissionDeniedErrorMessage": {
+    "message": "权限被拒绝",
+    "description": "权限被拒绝错误消息"
+  },
+  "timeoutErrorMessage": {
+    "message": "操作超时",
+    "description": "超时错误消息"
+  },
+  "indexedPagesLabel": {
+    "message": "已索引页面",
+    "description": "已索引页面数量标签"
+  },
+  "indexSizeLabel": {
+    "message": "索引大小",
+    "description": "索引大小标签"
+  },
+  "activeTabsLabel": {
+    "message": "活跃标签页",
+    "description": "活跃标签页数量标签"
+  },
+  "vectorDocumentsLabel": {
+    "message": "向量文档",
+    "description": "向量文档数量标签"
+  },
+  "cacheSizeLabel": {
+    "message": "缓存大小",
+    "description": "缓存大小标签"
+  },
+  "cacheEntriesLabel": {
+    "message": "缓存条目",
+    "description": "缓存条目数量标签"
+  },
+  "clearAllDataButton": {
+    "message": "清空所有数据",
+    "description": "清空所有数据按钮文本"
+  },
+  "clearAllCacheButton": {
+    "message": "清空所有缓存",
+    "description": "清空所有缓存按钮文本"
+  },
+  "cleanExpiredCacheButton": {
+    "message": "清理过期缓存",
+    "description": "清理过期缓存按钮文本"
+  },
+  "exportDataButton": {
+    "message": "导出数据",
+    "description": "导出数据按钮文本"
+  },
+  "importDataButton": {
+    "message": "导入数据",
+    "description": "导入数据按钮文本"
+  },
+  "confirmClearDataTitle": {
+    "message": "确认清空数据",
+    "description": "清空数据确认对话框标题"
+  },
+  "settingsTitle": {
+    "message": "设置",
+    "description": "设置对话框标题"
+  },
+  "aboutTitle": {
+    "message": "关于",
+    "description": "关于对话框标题"
+  },
+  "helpTitle": {
+    "message": "帮助",
+    "description": "帮助对话框标题"
+  },
+  "clearDataWarningMessage": {
+    "message": "此操作将清空所有已索引的网页内容和向量数据，包括：",
+    "description": "清空数据警告消息"
+  },
+  "clearDataList1": {
+    "message": "所有网页的文本内容索引",
+    "description": "清空数据列表第一项"
+  },
+  "clearDataList2": {
+    "message": "向量嵌入数据",
+    "description": "清空数据列表第二项"
+  },
+  "clearDataList3": {
+    "message": "搜索历史和缓存",
+    "description": "清空数据列表第三项"
+  },
+  "clearDataIrreversibleWarning": {
+    "message": "此操作不可撤销！清空后需要重新浏览网页来重建索引。",
+    "description": "不可逆操作警告"
+  },
+  "confirmClearButton": {
+    "message": "确认清空",
+    "description": "确认清空操作按钮"
+  },
+  "cacheDetailsLabel": {
+    "message": "缓存详情",
+    "description": "缓存详情节标签"
+  },
+  "noCacheDataMessage": {
+    "message": "暂无缓存数据",
+    "description": "无缓存数据可用消息"
+  },
+  "loadingCacheInfoStatus": {
+    "message": "正在加载缓存信息...",
+    "description": "加载缓存信息状态"
+  },
+  "processingCacheStatus": {
+    "message": "处理缓存中...",
+    "description": "处理缓存状态"
+  },
+  "expiredLabel": {
+    "message": "已过期",
+    "description": "过期项标签"
+  },
+  "bookmarksBarLabel": {
+    "message": "书签栏",
+    "description": "书签栏文件夹名称"
+  },
+  "newTabLabel": {
+    "message": "新标签页",
+    "description": "新标签页标签"
+  },
+  "currentPageLabel": {
+    "message": "当前页面",
+    "description": "当前页面标签"
+  },
+  "menuLabel": {
+    "message": "菜单",
+    "description": "菜单辅助功能标签"
+  },
+  "navigationLabel": {
+    "message": "导航",
+    "description": "导航辅助功能标签"
+  },
+  "mainContentLabel": {
+    "message": "主要内容",
+    "description": "主要内容辅助功能标签"
+  },
+  "languageSelectorLabel": {
+    "message": "语言",
+    "description": "语言选择器标签"
+  },
+  "themeLabel": {
+    "message": "主题",
+    "description": "主题选择器标签"
+  },
+  "lightTheme": {
+    "message": "浅色",
+    "description": "浅色主题选项"
+  },
+  "darkTheme": {
+    "message": "深色",
+    "description": "深色主题选项"
+  },
+  "autoTheme": {
+    "message": "自动",
+    "description": "自动主题选项"
+  },
+  "advancedSettingsLabel": {
+    "message": "高级设置",
+    "description": "高级设置节标签"
+  },
+  "debugModeLabel": {
+    "message": "调试模式",
+    "description": "调试模式切换标签"
+  },
+  "verboseLoggingLabel": {
+    "message": "详细日志",
+    "description": "详细日志切换标签"
+  },
+  "successNotification": {
+    "message": "操作成功完成",
+    "description": "通用成功通知"
+  },
+  "warningNotification": {
+    "message": "警告：请在继续之前检查",
+    "description": "通用警告通知"
+  },
+  "infoNotification": {
+    "message": "信息",
+    "description": "通用信息通知"
+  },
+  "configCopiedNotification": {
+    "message": "配置已复制到剪贴板",
+    "description": "配置复制成功消息"
+  },
+  "dataClearedNotification": {
+    "message": "数据清空成功",
+    "description": "数据清空成功消息"
+  },
+  "bytesUnit": {
+    "message": "字节",
+    "description": "字节单位"
+  },
+  "kilobytesUnit": {
+    "message": "KB",
+    "description": "千字节单位"
+  },
+  "megabytesUnit": {
+    "message": "MB",
+    "description": "兆字节单位"
+  },
+  "gigabytesUnit": {
+    "message": "GB",
+    "description": "吉字节单位"
+  },
+  "itemsUnit": {
+    "message": "项",
+    "description": "项目计数单位"
+  },
+  "pagesUnit": {
+    "message": "页",
+    "description": "页面计数单位"
+  }
+}

--- a/app/chrome-extension/entrypoints/background/tools/browser/bookmark.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/bookmark.ts
@@ -153,7 +153,7 @@ async function createFolderPath(
     const bookmarkBarFolder = rootChildren.find(
       (node) =>
         !node.url &&
-        (node.title === getMessage('bookmarksBar') ||
+        (node.title === getMessage('bookmarksBarLabel') ||
           node.title === 'Bookmarks bar' ||
           node.title === 'Bookmarks Bar'),
     );
@@ -435,7 +435,7 @@ class BookmarkAddTool extends BaseBrowserToolExecutor {
         const bookmarkBarFolder = rootChildren.find(
           (node) =>
             !node.url &&
-            (node.title === getMessage('bookmarksBar') ||
+            (node.title === getMessage('bookmarksBarLabel') ||
               node.title === 'Bookmarks bar' ||
               node.title === 'Bookmarks Bar'),
         );

--- a/app/chrome-extension/entrypoints/background/tools/browser/bookmark.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/bookmark.ts
@@ -1,6 +1,7 @@
 import { createErrorResponse, ToolResult } from '@/common/tool-handler';
 import { BaseBrowserToolExecutor } from '../base-browser';
 import { TOOL_NAMES } from 'chrome-mcp-shared';
+import { getMessage } from '@/utils/i18n';
 
 /**
  * Bookmark search tool parameters interface
@@ -152,7 +153,7 @@ async function createFolderPath(
     const bookmarkBarFolder = rootChildren.find(
       (node) =>
         !node.url &&
-        (node.title === '书签栏' ||
+        (node.title === getMessage('bookmarksBar') ||
           node.title === 'Bookmarks bar' ||
           node.title === 'Bookmarks Bar'),
     );
@@ -260,7 +261,9 @@ class BookmarkSearchTool extends BaseBrowserToolExecutor {
   async execute(args: BookmarkSearchToolParams): Promise<ToolResult> {
     const { query = '', maxResults = 50, folderPath } = args;
 
-    console.log(`BookmarkSearchTool: Searching bookmarks, keywords: "${query}", folder path: "${folderPath}"`);
+    console.log(
+      `BookmarkSearchTool: Searching bookmarks, keywords: "${query}", folder path: "${folderPath}"`,
+    );
 
     try {
       let bookmarksToSearch: chrome.bookmarks.BookmarkTreeNode[] = [];
@@ -432,7 +435,7 @@ class BookmarkAddTool extends BaseBrowserToolExecutor {
         const bookmarkBarFolder = rootChildren.find(
           (node) =>
             !node.url &&
-            (node.title === '书签栏' ||
+            (node.title === getMessage('bookmarksBar') ||
               node.title === 'Bookmarks bar' ||
               node.title === 'Bookmarks Bar'),
         );
@@ -519,7 +522,9 @@ class BookmarkDeleteTool extends BaseBrowserToolExecutor {
           if (nodes && nodes.length > 0 && nodes[0].url) {
             bookmarksToDelete = nodes;
           } else {
-            return createErrorResponse(`Bookmark with ID "${bookmarkId}" not found, or the ID does not correspond to a bookmark`);
+            return createErrorResponse(
+              `Bookmark with ID "${bookmarkId}" not found, or the ID does not correspond to a bookmark`,
+            );
           }
         } catch (error) {
           return createErrorResponse(`Invalid bookmark ID: "${bookmarkId}"`);
@@ -553,7 +558,9 @@ class BookmarkDeleteTool extends BaseBrowserToolExecutor {
           });
         } catch (error) {
           const errorMsg = error instanceof Error ? error.message : String(error);
-          errors.push(`Failed to delete bookmark "${bookmark.title}" (ID: ${bookmark.id}): ${errorMsg}`);
+          errors.push(
+            `Failed to delete bookmark "${bookmark.title}" (ID: ${bookmark.id}): ${errorMsg}`,
+          );
         }
       }
 

--- a/app/chrome-extension/entrypoints/popup/App.vue
+++ b/app/chrome-extension/entrypoints/popup/App.vue
@@ -7,15 +7,15 @@
     </div>
     <div class="content">
       <div class="section">
-        <h2 class="section-title">{{ getMessage('nativeServerConfig') }}</h2>
+        <h2 class="section-title">{{ getMessage('nativeServerConfigLabel') }}</h2>
         <div class="config-card">
           <div class="status-section">
             <div class="status-header">
-              <p class="status-label">{{ getMessage('runningStatus') }}</p>
+              <p class="status-label">{{ getMessage('runningStatusLabel') }}</p>
               <button
                 class="refresh-status-button"
                 @click="refreshServerStatus"
-                :title="getMessage('refreshStatus')"
+                :title="getMessage('refreshStatusButton')"
               >
                 🔄
               </button>
@@ -25,14 +25,14 @@
               <span class="status-text">{{ getStatusText() }}</span>
             </div>
             <div v-if="serverStatus.lastUpdated" class="status-timestamp">
-              {{ getMessage('lastUpdated') }}
+              {{ getMessage('lastUpdatedLabel') }}
               {{ new Date(serverStatus.lastUpdated).toLocaleTimeString() }}
             </div>
           </div>
 
           <div v-if="showMcpConfig" class="mcp-config-section">
             <div class="mcp-config-header">
-              <p class="mcp-config-label">{{ getMessage('mcpServerConfig') }}</p>
+              <p class="mcp-config-label">{{ getMessage('mcpServerConfigLabel') }}</p>
               <button class="copy-config-button" @click="copyMcpConfig">
                 {{ copyButtonText }}
               </button>
@@ -42,7 +42,7 @@
             </div>
           </div>
           <div class="port-section">
-            <label for="port" class="port-label">{{ getMessage('connectionPort') }}</label>
+            <label for="port" class="port-label">{{ getMessage('connectionPortLabel') }}</label>
             <input
               type="text"
               id="port"
@@ -56,17 +56,17 @@
             <BoltIcon />
             <span>{{
               isConnecting
-                ? getMessage('connecting')
+                ? getMessage('connectingStatus')
                 : nativeConnectionStatus === 'connected'
-                  ? getMessage('disconnect')
-                  : getMessage('connect')
+                  ? getMessage('disconnectButton')
+                  : getMessage('connectButton')
             }}</span>
           </button>
         </div>
       </div>
 
       <div class="section">
-        <h2 class="section-title">{{ getMessage('semanticEngine') }}</h2>
+        <h2 class="section-title">{{ getMessage('semanticEngineLabel') }}</h2>
         <div class="semantic-engine-card">
           <div class="semantic-engine-status">
             <div class="status-info">
@@ -74,7 +74,7 @@
               <span class="status-text">{{ getSemanticEngineStatusText() }}</span>
             </div>
             <div v-if="semanticEngineLastUpdated" class="status-timestamp">
-              {{ getMessage('lastUpdated') }}
+              {{ getMessage('lastUpdatedLabel') }}
               {{ new Date(semanticEngineLastUpdated).toLocaleTimeString() }}
             </div>
           </div>
@@ -98,7 +98,7 @@
       </div>
 
       <div class="section">
-        <h2 class="section-title">{{ getMessage('embeddingModel') }}</h2>
+        <h2 class="section-title">{{ getMessage('embeddingModelLabel') }}</h2>
 
         <ProgressIndicator
           v-if="isModelSwitching || isModelDownloading"
@@ -110,9 +110,9 @@
           <div class="error-content">
             <div class="error-icon">⚠️</div>
             <div class="error-details">
-              <p class="error-title">{{ getMessage('semanticEngineInitFailed') }}</p>
+              <p class="error-title">{{ getMessage('semanticEngineInitFailedStatus') }}</p>
               <p class="error-message">{{
-                modelErrorMessage || getMessage('semanticEngineInitFailed')
+                modelErrorMessage || getMessage('semanticEngineInitFailedStatus')
               }}</p>
               <p class="error-suggestion">{{ getErrorTypeText() }}</p>
             </div>
@@ -123,7 +123,7 @@
             :disabled="isModelSwitching || isModelDownloading"
           >
             <span>🔄</span>
-            <span>{{ getMessage('retry') }}</span>
+            <span>{{ getMessage('retryButton') }}</span>
           </button>
         </div>
 
@@ -163,11 +163,11 @@
       </div>
 
       <div class="section">
-        <h2 class="section-title">{{ getMessage('indexDataManagement') }}</h2>
+        <h2 class="section-title">{{ getMessage('indexDataManagementLabel') }}</h2>
         <div class="stats-grid">
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">{{ getMessage('indexedPages') }}</p>
+              <p class="stats-label">{{ getMessage('indexedPagesLabel') }}</p>
               <span class="stats-icon violet">
                 <DocumentIcon />
               </span>
@@ -177,7 +177,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">{{ getMessage('indexSize') }}</p>
+              <p class="stats-label">{{ getMessage('indexSizeLabel') }}</p>
               <span class="stats-icon teal">
                 <DatabaseIcon />
               </span>
@@ -187,7 +187,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">{{ getMessage('activeTabs') }}</p>
+              <p class="stats-label">{{ getMessage('activeTabsLabel') }}</p>
               <span class="stats-icon blue">
                 <TabIcon />
               </span>
@@ -197,7 +197,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">{{ getMessage('vectorDocuments') }}</p>
+              <p class="stats-label">{{ getMessage('vectorDocumentsLabel') }}</p>
               <span class="stats-icon green">
                 <VectorIcon />
               </span>
@@ -218,7 +218,7 @@
           @click="showClearConfirmation = true"
         >
           <TrashIcon />
-          <span>{{ isClearingData ? getMessage('clearing') : getMessage('clearAllData') }}</span>
+          <span>{{ isClearingData ? getMessage('clearingStatus') : getMessage('clearAllDataButton') }}</span>
         </button>
       </div>
 
@@ -237,18 +237,18 @@
 
     <ConfirmDialog
       :visible="showClearConfirmation"
-      :title="getMessage('confirmClearData')"
-      :message="getMessage('clearDataWarning')"
+      :title="getMessage('confirmClearDataTitle')"
+      :message="getMessage('clearDataWarningMessage')"
       :items="[
         getMessage('clearDataList1'),
         getMessage('clearDataList2'),
         getMessage('clearDataList3'),
       ]"
-      :warning="getMessage('clearDataIrreversible')"
+      :warning="getMessage('clearDataIrreversibleWarning')"
       icon="⚠️"
-      :confirm-text="getMessage('confirmClear')"
-      :cancel-text="getMessage('cancel')"
-      :confirming-text="getMessage('clearing')"
+      :confirm-text="getMessage('confirmClearButton')"
+      :cancel-text="getMessage('cancelButton')"
+      :confirming-text="getMessage('clearingStatus')"
       :is-confirming="isClearingData"
       @confirm="confirmClearAllData"
       @cancel="hideClearDataConfirmation"
@@ -299,7 +299,7 @@ const showMcpConfig = computed(() => {
   return nativeConnectionStatus.value === 'connected' && serverStatus.value.isRunning;
 });
 
-const copyButtonText = ref(getMessage('copyConfig'));
+const copyButtonText = ref(getMessage('copyConfigButton'));
 
 const mcpConfigJson = computed(() => {
   const port = serverStatus.value.port || nativeServerPort.value;
@@ -385,14 +385,14 @@ const getStatusClass = () => {
 const getStatusText = () => {
   if (nativeConnectionStatus.value === 'connected') {
     if (serverStatus.value.isRunning) {
-      return getMessage('serviceRunning', [(serverStatus.value.port || 'Unknown').toString()]);
+      return getMessage('serviceRunningStatus', [(serverStatus.value.port || 'Unknown').toString()]);
     } else {
-      return getMessage('connectedServiceNotStarted');
+      return getMessage('connectedServiceNotStartedStatus');
     }
   } else if (nativeConnectionStatus.value === 'disconnected') {
-    return getMessage('serviceNotConnected');
+    return getMessage('serviceNotConnectedStatus');
   } else {
-    return getMessage('detecting');
+    return getMessage('detectingStatus');
   }
 };
 
@@ -405,22 +405,22 @@ const formatIndexSize = () => {
 const getModelDescription = (model: any) => {
   switch (model.preset) {
     case 'multilingual-e5-small':
-      return getMessage('lightweightModel');
+      return getMessage('lightweightModelDescription');
     case 'multilingual-e5-base':
-      return getMessage('betterThanSmall');
+      return getMessage('betterThanSmallDescription');
     default:
-      return getMessage('multilingualModel');
+      return getMessage('multilingualModelDescription');
   }
 };
 
 const getPerformanceText = (performance: string) => {
   switch (performance) {
     case 'fast':
-      return getMessage('fast');
+      return getMessage('fastPerformance');
     case 'balanced':
-      return getMessage('balanced');
+      return getMessage('balancedPerformance');
     case 'accurate':
-      return getMessage('accurate');
+      return getMessage('accuratePerformance');
     default:
       return performance;
   }
@@ -429,14 +429,14 @@ const getPerformanceText = (performance: string) => {
 const getSemanticEngineStatusText = () => {
   switch (semanticEngineStatus.value) {
     case 'ready':
-      return getMessage('semanticEngineReady');
+      return getMessage('semanticEngineReadyStatus');
     case 'initializing':
-      return getMessage('semanticEngineInitializing');
+      return getMessage('semanticEngineInitializingStatus');
     case 'error':
-      return getMessage('semanticEngineInitFailed');
+      return getMessage('semanticEngineInitFailedStatus');
     case 'idle':
     default:
-      return getMessage('semanticEngineNotInit');
+      return getMessage('semanticEngineNotInitStatus');
   }
 };
 
@@ -460,9 +460,9 @@ const getActiveTabsCount = () => {
 
 const getProgressText = () => {
   if (isModelDownloading.value) {
-    return getMessage('downloadingModel', [modelDownloadProgress.value.toString()]);
+    return getMessage('downloadingModelStatus', [modelDownloadProgress.value.toString()]);
   } else if (isModelSwitching.value) {
-    return modelSwitchProgress.value || getMessage('switchingModel');
+    return modelSwitchProgress.value || getMessage('switchingModelStatus');
   }
   return '';
 };
@@ -470,26 +470,26 @@ const getProgressText = () => {
 const getErrorTypeText = () => {
   switch (modelErrorType.value) {
     case 'network':
-      return getMessage('networkError');
+      return getMessage('networkErrorMessage');
     case 'file':
-      return getMessage('modelCorrupted');
+      return getMessage('modelCorruptedErrorMessage');
     case 'unknown':
     default:
-      return getMessage('unknownError');
+      return getMessage('unknownErrorMessage');
   }
 };
 
 const getSemanticEngineButtonText = () => {
   switch (semanticEngineStatus.value) {
     case 'ready':
-      return getMessage('reinitialize');
+      return getMessage('reinitializeButton');
     case 'initializing':
-      return getMessage('initializing');
+      return getMessage('initializingStatus');
     case 'error':
-      return getMessage('reinitialize');
+      return getMessage('reinitializeButton');
     case 'idle':
     default:
-      return getMessage('initSemanticEngine');
+      return getMessage('initSemanticEngineButton');
   }
 };
 
@@ -556,8 +556,8 @@ const initializeSemanticEngine = async () => {
   isSemanticEngineInitializing.value = true;
   semanticEngineStatus.value = 'initializing';
   semanticEngineInitProgress.value = isReinitialization
-    ? '正在重新初始化语义引擎...'
-    : '正在初始化语义引擎...';
+    ? getMessage('semanticEngineInitializingStatus')
+    : getMessage('semanticEngineInitializingStatus');
   semanticEngineLastUpdated.value = Date.now();
 
   await saveSemanticEngineState();
@@ -575,12 +575,12 @@ const initializeSemanticEngine = async () => {
     startSemanticEngineStatusPolling();
 
     semanticEngineInitProgress.value = isReinitialization
-      ? '重新初始化请求已发送，正在后台处理...'
-      : '初始化请求已发送，正在后台处理...';
+      ? getMessage('processingStatus')
+      : getMessage('processingStatus');
   } catch (error: any) {
     console.error('❌ Failed to send initialization request:', error);
     semanticEngineStatus.value = 'error';
-    semanticEngineInitProgress.value = `发送初始化请求失败: ${error?.message || '未知错误'}`;
+    semanticEngineInitProgress.value = `Failed to send initialization request: ${error?.message || 'Unknown error'}`;
 
     await saveSemanticEngineState();
 
@@ -608,7 +608,7 @@ const checkSemanticEngineStatus = async () => {
         semanticEngineStatus.value = 'ready';
         semanticEngineLastUpdated.value = Date.now();
         isSemanticEngineInitializing.value = false;
-        semanticEngineInitProgress.value = '语义引擎初始化成功！';
+        semanticEngineInitProgress.value = getMessage('semanticEngineReadyStatus');
         await saveSemanticEngineState();
         stopSemanticEngineStatusPolling();
         setTimeout(() => {
@@ -620,14 +620,14 @@ const checkSemanticEngineStatus = async () => {
       ) {
         semanticEngineStatus.value = 'initializing';
         isSemanticEngineInitializing.value = true;
-        semanticEngineInitProgress.value = '正在初始化语义引擎...';
+        semanticEngineInitProgress.value = getMessage('semanticEngineInitializingStatus');
         semanticEngineLastUpdated.value = Date.now();
         await saveSemanticEngineState();
       } else if (status.initializationStatus === 'error') {
         semanticEngineStatus.value = 'error';
         semanticEngineLastUpdated.value = Date.now();
         isSemanticEngineInitializing.value = false;
-        semanticEngineInitProgress.value = '语义引擎初始化失败';
+        semanticEngineInitProgress.value = getMessage('semanticEngineInitFailedStatus');
         await saveSemanticEngineState();
         stopSemanticEngineStatusPolling();
         setTimeout(() => {
@@ -722,17 +722,17 @@ const refreshServerStatus = async () => {
 const copyMcpConfig = async () => {
   try {
     await navigator.clipboard.writeText(mcpConfigJson.value);
-    copyButtonText.value = '✅已复制';
+    copyButtonText.value = '✅' + getMessage('configCopiedNotification');
 
     setTimeout(() => {
-      copyButtonText.value = '复制配置';
+      copyButtonText.value = getMessage('copyConfigButton');
     }, 2000);
   } catch (error) {
     console.error('复制配置失败:', error);
-    copyButtonText.value = '❌复制失败';
+    copyButtonText.value = '❌' + getMessage('networkErrorMessage');
 
     setTimeout(() => {
-      copyButtonText.value = '复制配置';
+      copyButtonText.value = getMessage('copyConfigButton');
     }, 2000);
   }
 };
@@ -921,7 +921,7 @@ const startModelStatusMonitoring = () => {
         isModelDownloading.value = status.isDownloading || false;
 
         if (status.initializationStatus === 'error') {
-          modelErrorMessage.value = status.errorMessage || '模型加载失败';
+          modelErrorMessage.value = status.errorMessage || getMessage('modelFailedStatus');
           modelErrorType.value = status.errorType || 'unknown';
         } else {
           modelErrorMessage.value = '';
@@ -1021,7 +1021,7 @@ const confirmClearAllData = async () => {
   if (isClearingData.value) return;
 
   isClearingData.value = true;
-  clearDataProgress.value = '正在清空所有数据...';
+  clearDataProgress.value = getMessage('clearingStatus');
 
   try {
     console.log('🗑️ Starting to clear all data...');
@@ -1032,7 +1032,7 @@ const confirmClearAllData = async () => {
     });
 
     if (response && response.success) {
-      clearDataProgress.value = '数据清空成功！';
+      clearDataProgress.value = getMessage('dataClearedNotification');
       console.log('✅ All data cleared successfully');
 
       await refreshStorageStats();
@@ -1042,11 +1042,11 @@ const confirmClearAllData = async () => {
         hideClearDataConfirmation();
       }, 2000);
     } else {
-      throw new Error(response?.error || '清空数据失败');
+      throw new Error(response?.error || 'Failed to clear data');
     }
   } catch (error: any) {
     console.error('❌ Failed to clear all data:', error);
-    clearDataProgress.value = `清空数据失败: ${error?.message || '未知错误'}`;
+    clearDataProgress.value = `Failed to clear data: ${error?.message || 'Unknown error'}`;
 
     setTimeout(() => {
       clearDataProgress.value = '';
@@ -1093,7 +1093,7 @@ const switchModel = async (newModel: ModelPreset) => {
   );
 
   isModelSwitching.value = true;
-  modelSwitchProgress.value = '正在切换模型...';
+  modelSwitchProgress.value = getMessage('switchingModelStatus');
 
   modelInitializationStatus.value = 'downloading';
   modelDownloadProgress.value = 0;
@@ -1104,7 +1104,7 @@ const switchModel = async (newModel: ModelPreset) => {
     await saveVersionPreference('quantized');
     await saveModelState();
 
-    modelSwitchProgress.value = '正在重新初始化语义引擎...';
+    modelSwitchProgress.value = getMessage('semanticEngineInitializingStatus');
 
     startModelStatusMonitoring();
 
@@ -1119,7 +1119,7 @@ const switchModel = async (newModel: ModelPreset) => {
 
     if (response && response.success) {
       currentModel.value = newModel;
-      modelSwitchProgress.value = '模型切换成功！';
+      modelSwitchProgress.value = getMessage('successNotification');
       console.log(
         '模型切换成功:',
         newModel,
@@ -1136,11 +1136,11 @@ const switchModel = async (newModel: ModelPreset) => {
         modelSwitchProgress.value = '';
       }, 2000);
     } else {
-      throw new Error(response?.error || '模型切换失败');
+      throw new Error(response?.error || 'Model switch failed');
     }
   } catch (error: any) {
     console.error('模型切换失败:', error);
-    modelSwitchProgress.value = `模型切换失败: ${error?.message || '未知错误'}`;
+    modelSwitchProgress.value = `Model switch failed: ${error?.message || 'Unknown error'}`;
 
     modelInitializationStatus.value = 'error';
     isModelDownloading.value = false;
@@ -1152,14 +1152,14 @@ const switchModel = async (newModel: ModelPreset) => {
       errorMessage.includes('timeout')
     ) {
       modelErrorType.value = 'network';
-      modelErrorMessage.value = '网络连接失败，无法下载模型文件';
+      modelErrorMessage.value = getMessage('networkErrorMessage');
     } else if (
       errorMessage.includes('corrupt') ||
       errorMessage.includes('invalid') ||
       errorMessage.includes('format')
     ) {
       modelErrorType.value = 'file';
-      modelErrorMessage.value = '模型文件损坏或格式错误';
+      modelErrorMessage.value = getMessage('modelCorruptedErrorMessage');
     } else {
       modelErrorType.value = 'unknown';
       modelErrorMessage.value = errorMessage;

--- a/app/chrome-extension/entrypoints/popup/App.vue
+++ b/app/chrome-extension/entrypoints/popup/App.vue
@@ -7,12 +7,16 @@
     </div>
     <div class="content">
       <div class="section">
-        <h2 class="section-title">Native Server 配置</h2>
+        <h2 class="section-title">{{ getMessage('nativeServerConfig') }}</h2>
         <div class="config-card">
           <div class="status-section">
             <div class="status-header">
-              <p class="status-label">运行状态</p>
-              <button class="refresh-status-button" @click="refreshServerStatus" title="刷新状态">
+              <p class="status-label">{{ getMessage('runningStatus') }}</p>
+              <button
+                class="refresh-status-button"
+                @click="refreshServerStatus"
+                :title="getMessage('refreshStatus')"
+              >
                 🔄
               </button>
             </div>
@@ -21,13 +25,14 @@
               <span class="status-text">{{ getStatusText() }}</span>
             </div>
             <div v-if="serverStatus.lastUpdated" class="status-timestamp">
-              最后更新: {{ new Date(serverStatus.lastUpdated).toLocaleTimeString() }}
+              {{ getMessage('lastUpdated') }}
+              {{ new Date(serverStatus.lastUpdated).toLocaleTimeString() }}
             </div>
           </div>
 
           <div v-if="showMcpConfig" class="mcp-config-section">
             <div class="mcp-config-header">
-              <p class="mcp-config-label">MCP 服务器配置</p>
+              <p class="mcp-config-label">{{ getMessage('mcpServerConfig') }}</p>
               <button class="copy-config-button" @click="copyMcpConfig">
                 {{ copyButtonText }}
               </button>
@@ -37,7 +42,7 @@
             </div>
           </div>
           <div class="port-section">
-            <label for="port" class="port-label">连接端口</label>
+            <label for="port" class="port-label">{{ getMessage('connectionPort') }}</label>
             <input
               type="text"
               id="port"
@@ -50,14 +55,18 @@
           <button class="connect-button" :disabled="isConnecting" @click="testNativeConnection">
             <BoltIcon />
             <span>{{
-              isConnecting ? '连接中...' : nativeConnectionStatus === 'connected' ? '断开' : '连接'
+              isConnecting
+                ? getMessage('connecting')
+                : nativeConnectionStatus === 'connected'
+                  ? getMessage('disconnect')
+                  : getMessage('connect')
             }}</span>
           </button>
         </div>
       </div>
 
       <div class="section">
-        <h2 class="section-title">语义引擎</h2>
+        <h2 class="section-title">{{ getMessage('semanticEngine') }}</h2>
         <div class="semantic-engine-card">
           <div class="semantic-engine-status">
             <div class="status-info">
@@ -65,7 +74,8 @@
               <span class="status-text">{{ getSemanticEngineStatusText() }}</span>
             </div>
             <div v-if="semanticEngineLastUpdated" class="status-timestamp">
-              最后更新: {{ new Date(semanticEngineLastUpdated).toLocaleTimeString() }}
+              {{ getMessage('lastUpdated') }}
+              {{ new Date(semanticEngineLastUpdated).toLocaleTimeString() }}
             </div>
           </div>
 
@@ -88,7 +98,7 @@
       </div>
 
       <div class="section">
-        <h2 class="section-title">Embedding模型</h2>
+        <h2 class="section-title">{{ getMessage('embeddingModel') }}</h2>
 
         <ProgressIndicator
           v-if="isModelSwitching || isModelDownloading"
@@ -100,8 +110,10 @@
           <div class="error-content">
             <div class="error-icon">⚠️</div>
             <div class="error-details">
-              <p class="error-title">模型初始化失败</p>
-              <p class="error-message">{{ modelErrorMessage || '模型加载失败' }}</p>
+              <p class="error-title">{{ getMessage('semanticEngineInitFailed') }}</p>
+              <p class="error-message">{{
+                modelErrorMessage || getMessage('semanticEngineInitFailed')
+              }}</p>
               <p class="error-suggestion">{{ getErrorTypeText() }}</p>
             </div>
           </div>
@@ -111,7 +123,7 @@
             :disabled="isModelSwitching || isModelDownloading"
           >
             <span>🔄</span>
-            <span>重试</span>
+            <span>{{ getMessage('retry') }}</span>
           </button>
         </div>
 
@@ -151,11 +163,11 @@
       </div>
 
       <div class="section">
-        <h2 class="section-title">索引数据管理</h2>
+        <h2 class="section-title">{{ getMessage('indexDataManagement') }}</h2>
         <div class="stats-grid">
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">已索引页面</p>
+              <p class="stats-label">{{ getMessage('indexedPages') }}</p>
               <span class="stats-icon violet">
                 <DocumentIcon />
               </span>
@@ -165,7 +177,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">索引大小</p>
+              <p class="stats-label">{{ getMessage('indexSize') }}</p>
               <span class="stats-icon teal">
                 <DatabaseIcon />
               </span>
@@ -175,7 +187,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">活跃标签页</p>
+              <p class="stats-label">{{ getMessage('activeTabs') }}</p>
               <span class="stats-icon blue">
                 <TabIcon />
               </span>
@@ -185,7 +197,7 @@
 
           <div class="stats-card">
             <div class="stats-header">
-              <p class="stats-label">向量文档</p>
+              <p class="stats-label">{{ getMessage('vectorDocuments') }}</p>
               <span class="stats-icon green">
                 <VectorIcon />
               </span>
@@ -206,7 +218,7 @@
           @click="showClearConfirmation = true"
         >
           <TrashIcon />
-          <span>{{ isClearingData ? '清空中...' : '清空所有数据' }}</span>
+          <span>{{ isClearingData ? getMessage('clearing') : getMessage('clearAllData') }}</span>
         </button>
       </div>
 
@@ -225,14 +237,18 @@
 
     <ConfirmDialog
       :visible="showClearConfirmation"
-      title="确认清空数据"
-      message="此操作将清空所有已索引的网页内容和向量数据，包括："
-      :items="['所有网页的文本内容索引', '向量嵌入数据', '搜索历史和缓存']"
-      warning="此操作不可撤销！清空后需要重新浏览网页来重建索引。"
+      :title="getMessage('confirmClearData')"
+      :message="getMessage('clearDataWarning')"
+      :items="[
+        getMessage('clearDataList1'),
+        getMessage('clearDataList2'),
+        getMessage('clearDataList3'),
+      ]"
+      :warning="getMessage('clearDataIrreversible')"
       icon="⚠️"
-      confirm-text="确认清空"
-      cancel-text="取消"
-      confirming-text="清空中..."
+      :confirm-text="getMessage('confirmClear')"
+      :cancel-text="getMessage('cancel')"
+      :confirming-text="getMessage('clearing')"
       :is-confirming="isClearingData"
       @confirm="confirmClearAllData"
       @cancel="hideClearDataConfirmation"
@@ -251,6 +267,7 @@ import {
   cleanupModelCache,
 } from '@/utils/semantic-similarity-engine';
 import { BACKGROUND_MESSAGE_TYPES } from '@/common/message-types';
+import { getMessage } from '@/utils/i18n';
 
 import ConfirmDialog from './components/ConfirmDialog.vue';
 import ProgressIndicator from './components/ProgressIndicator.vue';
@@ -282,7 +299,7 @@ const showMcpConfig = computed(() => {
   return nativeConnectionStatus.value === 'connected' && serverStatus.value.isRunning;
 });
 
-const copyButtonText = ref('复制配置');
+const copyButtonText = ref(getMessage('copyConfig'));
 
 const mcpConfigJson = computed(() => {
   const port = serverStatus.value.port || nativeServerPort.value;
@@ -368,14 +385,14 @@ const getStatusClass = () => {
 const getStatusText = () => {
   if (nativeConnectionStatus.value === 'connected') {
     if (serverStatus.value.isRunning) {
-      return `服务运行中 (端口: ${serverStatus.value.port || 'Unknown'})`;
+      return getMessage('serviceRunning', [(serverStatus.value.port || 'Unknown').toString()]);
     } else {
-      return '已连接，服务未启动';
+      return getMessage('connectedServiceNotStarted');
     }
   } else if (nativeConnectionStatus.value === 'disconnected') {
-    return '服务未连接';
+    return getMessage('serviceNotConnected');
   } else {
-    return '检测中...';
+    return getMessage('detecting');
   }
 };
 
@@ -388,22 +405,22 @@ const formatIndexSize = () => {
 const getModelDescription = (model: any) => {
   switch (model.preset) {
     case 'multilingual-e5-small':
-      return '轻量级多语言模型';
+      return getMessage('lightweightModel');
     case 'multilingual-e5-base':
-      return '比e5-small稍大，但效果更好';
+      return getMessage('betterThanSmall');
     default:
-      return '多语言语义模型';
+      return getMessage('multilingualModel');
   }
 };
 
 const getPerformanceText = (performance: string) => {
   switch (performance) {
     case 'fast':
-      return '快速';
+      return getMessage('fast');
     case 'balanced':
-      return '平衡';
+      return getMessage('balanced');
     case 'accurate':
-      return '精确';
+      return getMessage('accurate');
     default:
       return performance;
   }
@@ -412,14 +429,14 @@ const getPerformanceText = (performance: string) => {
 const getSemanticEngineStatusText = () => {
   switch (semanticEngineStatus.value) {
     case 'ready':
-      return '语义引擎已就绪';
+      return getMessage('semanticEngineReady');
     case 'initializing':
-      return '语义引擎初始化中...';
+      return getMessage('semanticEngineInitializing');
     case 'error':
-      return '语义引擎初始化失败';
+      return getMessage('semanticEngineInitFailed');
     case 'idle':
     default:
-      return '语义引擎未初始化';
+      return getMessage('semanticEngineNotInit');
   }
 };
 
@@ -443,9 +460,9 @@ const getActiveTabsCount = () => {
 
 const getProgressText = () => {
   if (isModelDownloading.value) {
-    return `下载模型中... ${modelDownloadProgress.value}%`;
+    return getMessage('downloadingModel', [modelDownloadProgress.value.toString()]);
   } else if (isModelSwitching.value) {
-    return modelSwitchProgress.value || '切换模型中...';
+    return modelSwitchProgress.value || getMessage('switchingModel');
   }
   return '';
 };
@@ -453,26 +470,26 @@ const getProgressText = () => {
 const getErrorTypeText = () => {
   switch (modelErrorType.value) {
     case 'network':
-      return '网络连接错误，请检查网络连接后重试';
+      return getMessage('networkError');
     case 'file':
-      return '模型文件损坏或不完整，请重试下载';
+      return getMessage('modelCorrupted');
     case 'unknown':
     default:
-      return '未知错误，请检查你的网络是否可以访问huggingface';
+      return getMessage('unknownError');
   }
 };
 
 const getSemanticEngineButtonText = () => {
   switch (semanticEngineStatus.value) {
     case 'ready':
-      return '重新初始化';
+      return getMessage('reinitialize');
     case 'initializing':
-      return '初始化中...';
+      return getMessage('initializing');
     case 'error':
-      return '重新初始化';
+      return getMessage('reinitialize');
     case 'idle':
     default:
-      return '初始化语义引擎';
+      return getMessage('initSemanticEngine');
   }
 };
 

--- a/app/chrome-extension/entrypoints/popup/components/ConfirmDialog.vue
+++ b/app/chrome-extension/entrypoints/popup/components/ConfirmDialog.vue
@@ -56,9 +56,9 @@ interface Emits {
 
 withDefaults(defineProps<Props>(), {
   icon: '⚠️',
-  confirmText: getMessage('confirm'),
-  cancelText: getMessage('cancel'),
-  confirmingText: getMessage('processing'),
+  confirmText: getMessage('confirmButton'),
+  cancelText: getMessage('cancelButton'),
+  confirmingText: getMessage('processingStatus'),
   isConfirming: false,
 });
 

--- a/app/chrome-extension/entrypoints/popup/components/ConfirmDialog.vue
+++ b/app/chrome-extension/entrypoints/popup/components/ConfirmDialog.vue
@@ -35,6 +35,7 @@
 </template>
 
 <script lang="ts" setup>
+import { getMessage } from '@/utils/i18n';
 interface Props {
   visible: boolean;
   title: string;
@@ -55,9 +56,9 @@ interface Emits {
 
 withDefaults(defineProps<Props>(), {
   icon: '⚠️',
-  confirmText: '确认',
-  cancelText: '取消',
-  confirmingText: '处理中...',
+  confirmText: getMessage('confirm'),
+  cancelText: getMessage('cancel'),
+  confirmingText: getMessage('processing'),
   isConfirming: false,
 });
 

--- a/app/chrome-extension/entrypoints/popup/components/ModelCacheManagement.vue
+++ b/app/chrome-extension/entrypoints/popup/components/ModelCacheManagement.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="model-cache-section">
-    <h2 class="section-title">{{ getMessage('modelCacheManagement') }}</h2>
+    <h2 class="section-title">{{ getMessage('modelCacheManagementLabel') }}</h2>
 
     <!-- Cache Statistics Grid -->
     <div class="stats-grid">
       <div class="stats-card">
         <div class="stats-header">
-          <p class="stats-label">{{ getMessage('cacheSize') }}</p>
+          <p class="stats-label">{{ getMessage('cacheSizeLabel') }}</p>
           <span class="stats-icon orange">
             <DatabaseIcon />
           </span>
@@ -16,7 +16,7 @@
 
       <div class="stats-card">
         <div class="stats-header">
-          <p class="stats-label">{{ getMessage('cacheEntries') }}</p>
+          <p class="stats-label">{{ getMessage('cacheEntriesLabel') }}</p>
           <span class="stats-icon purple">
             <VectorIcon />
           </span>
@@ -27,7 +27,7 @@
 
     <!-- Cache Entries Details -->
     <div v-if="cacheStats && cacheStats.entries.length > 0" class="cache-details">
-      <h3 class="cache-details-title">{{ getMessage('cacheDetails') }}</h3>
+      <h3 class="cache-details-title">{{ getMessage('cacheDetailsLabel') }}</h3>
       <div class="cache-entries">
         <div v-for="entry in cacheStats.entries" :key="entry.url" class="cache-entry">
           <div class="entry-info">
@@ -35,7 +35,7 @@
             <div class="entry-details">
               <span class="entry-size">{{ entry.sizeMB }} MB</span>
               <span class="entry-age">{{ entry.age }}</span>
-              <span v-if="entry.expired" class="entry-expired">{{ getMessage('expired') }}</span>
+              <span v-if="entry.expired" class="entry-expired">{{ getMessage('expiredLabel') }}</span>
             </div>
           </div>
         </div>
@@ -44,19 +44,19 @@
 
     <!-- No Cache Message -->
     <div v-else-if="cacheStats && cacheStats.entries.length === 0" class="no-cache">
-      <p>{{ getMessage('noCacheData') }}</p>
+      <p>{{ getMessage('noCacheDataMessage') }}</p>
     </div>
 
     <!-- Loading State -->
     <div v-else-if="!cacheStats" class="loading-cache">
-      <p>{{ getMessage('loadingCacheInfo') }}</p>
+      <p>{{ getMessage('loadingCacheInfoStatus') }}</p>
     </div>
 
     <!-- Progress Indicator -->
     <ProgressIndicator
       v-if="isManagingCache"
       :visible="isManagingCache"
-      :text="isManagingCache ? getMessage('processingCache') : ''"
+      :text="isManagingCache ? getMessage('processingCacheStatus') : ''"
       :showSpinner="true"
     />
 
@@ -65,13 +65,13 @@
       <div class="secondary-button" :disabled="isManagingCache" @click="$emit('cleanup-cache')">
         <span class="stats-icon"><DatabaseIcon /></span>
         <span>{{
-          isManagingCache ? getMessage('cleaning') : getMessage('cleanExpiredCache')
+          isManagingCache ? getMessage('cleaningStatus') : getMessage('cleanExpiredCacheButton')
         }}</span>
       </div>
 
       <div class="danger-button" :disabled="isManagingCache" @click="$emit('clear-all-cache')">
         <span class="stats-icon"><TrashIcon /></span>
-        <span>{{ isManagingCache ? getMessage('clearing') : getMessage('clearAllCache') }}</span>
+        <span>{{ isManagingCache ? getMessage('clearingStatus') : getMessage('clearAllCacheButton') }}</span>
       </div>
     </div>
   </div>

--- a/app/chrome-extension/entrypoints/popup/components/ModelCacheManagement.vue
+++ b/app/chrome-extension/entrypoints/popup/components/ModelCacheManagement.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="model-cache-section">
-    <h2 class="section-title">模型缓存管理</h2>
+    <h2 class="section-title">{{ getMessage('modelCacheManagement') }}</h2>
 
     <!-- Cache Statistics Grid -->
     <div class="stats-grid">
       <div class="stats-card">
         <div class="stats-header">
-          <p class="stats-label">缓存大小</p>
+          <p class="stats-label">{{ getMessage('cacheSize') }}</p>
           <span class="stats-icon orange">
             <DatabaseIcon />
           </span>
@@ -16,7 +16,7 @@
 
       <div class="stats-card">
         <div class="stats-header">
-          <p class="stats-label">缓存条目</p>
+          <p class="stats-label">{{ getMessage('cacheEntries') }}</p>
           <span class="stats-icon purple">
             <VectorIcon />
           </span>
@@ -27,7 +27,7 @@
 
     <!-- Cache Entries Details -->
     <div v-if="cacheStats && cacheStats.entries.length > 0" class="cache-details">
-      <h3 class="cache-details-title">缓存详情</h3>
+      <h3 class="cache-details-title">{{ getMessage('cacheDetails') }}</h3>
       <div class="cache-entries">
         <div v-for="entry in cacheStats.entries" :key="entry.url" class="cache-entry">
           <div class="entry-info">
@@ -35,7 +35,7 @@
             <div class="entry-details">
               <span class="entry-size">{{ entry.sizeMB }} MB</span>
               <span class="entry-age">{{ entry.age }}</span>
-              <span v-if="entry.expired" class="entry-expired">已过期</span>
+              <span v-if="entry.expired" class="entry-expired">{{ getMessage('expired') }}</span>
             </div>
           </div>
         </div>
@@ -44,19 +44,19 @@
 
     <!-- No Cache Message -->
     <div v-else-if="cacheStats && cacheStats.entries.length === 0" class="no-cache">
-      <p>暂无缓存数据</p>
+      <p>{{ getMessage('noCacheData') }}</p>
     </div>
 
     <!-- Loading State -->
     <div v-else-if="!cacheStats" class="loading-cache">
-      <p>正在加载缓存信息...</p>
+      <p>{{ getMessage('loadingCacheInfo') }}</p>
     </div>
 
     <!-- Progress Indicator -->
     <ProgressIndicator
       v-if="isManagingCache"
       :visible="isManagingCache"
-      :text="isManagingCache ? '处理缓存中...' : ''"
+      :text="isManagingCache ? getMessage('processingCache') : ''"
       :showSpinner="true"
     />
 
@@ -64,12 +64,14 @@
     <div class="cache-actions">
       <div class="secondary-button" :disabled="isManagingCache" @click="$emit('cleanup-cache')">
         <span class="stats-icon"><DatabaseIcon /></span>
-        <span>{{ isManagingCache ? '清理中...' : '清理过期缓存' }}</span>
+        <span>{{
+          isManagingCache ? getMessage('cleaning') : getMessage('cleanExpiredCache')
+        }}</span>
       </div>
 
       <div class="danger-button" :disabled="isManagingCache" @click="$emit('clear-all-cache')">
         <span class="stats-icon"><TrashIcon /></span>
-        <span>{{ isManagingCache ? '清空中...' : '清空所有缓存' }}</span>
+        <span>{{ isManagingCache ? getMessage('clearing') : getMessage('clearAllCache') }}</span>
       </div>
     </div>
   </div>
@@ -78,6 +80,7 @@
 <script lang="ts" setup>
 import ProgressIndicator from './ProgressIndicator.vue';
 import { DatabaseIcon, VectorIcon, TrashIcon } from './icons';
+import { getMessage } from '@/utils/i18n';
 
 interface CacheEntry {
   url: string;

--- a/app/chrome-extension/utils/i18n.ts
+++ b/app/chrome-extension/utils/i18n.ts
@@ -1,0 +1,273 @@
+/**
+ * Chrome Extension i18n utility
+ * Provides safe access to chrome.i18n.getMessage with fallbacks
+ */
+
+// Fallback messages for when Chrome APIs aren't available (English)
+const fallbackMessages: Record<string, string> = {
+  // Extension metadata
+  extensionName: 'chrome-mcp-server',
+  extensionDescription: 'Exposes browser capabilities with your own chrome',
+
+  // Section headers
+  nativeServerConfigLabel: 'Native Server Configuration',
+  semanticEngineLabel: 'Semantic Engine',
+  embeddingModelLabel: 'Embedding Model',
+  indexDataManagementLabel: 'Index Data Management',
+  modelCacheManagementLabel: 'Model Cache Management',
+
+  // Status labels
+  statusLabel: 'Status',
+  runningStatusLabel: 'Running Status',
+  connectionStatusLabel: 'Connection Status',
+  lastUpdatedLabel: 'Last Updated:',
+
+  // Connection states
+  connectButton: 'Connect',
+  disconnectButton: 'Disconnect',
+  connectingStatus: 'Connecting...',
+  connectedStatus: 'Connected',
+  disconnectedStatus: 'Disconnected',
+  detectingStatus: 'Detecting...',
+
+  // Server states
+  serviceRunningStatus: 'Service Running (Port: {0})',
+  serviceNotConnectedStatus: 'Service Not Connected',
+  connectedServiceNotStartedStatus: 'Connected, Service Not Started',
+
+  // Configuration labels
+  mcpServerConfigLabel: 'MCP Server Configuration',
+  connectionPortLabel: 'Connection Port',
+  refreshStatusButton: 'Refresh Status',
+  copyConfigButton: 'Copy Configuration',
+
+  // Action buttons
+  retryButton: 'Retry',
+  cancelButton: 'Cancel',
+  confirmButton: 'Confirm',
+  saveButton: 'Save',
+  closeButton: 'Close',
+  resetButton: 'Reset',
+
+  // Progress states
+  initializingStatus: 'Initializing...',
+  processingStatus: 'Processing...',
+  loadingStatus: 'Loading...',
+  clearingStatus: 'Clearing...',
+  cleaningStatus: 'Cleaning...',
+  downloadingStatus: 'Downloading...',
+
+  // Semantic engine states
+  semanticEngineReadyStatus: 'Semantic Engine Ready',
+  semanticEngineInitializingStatus: 'Semantic Engine Initializing...',
+  semanticEngineInitFailedStatus: 'Semantic Engine Initialization Failed',
+  semanticEngineNotInitStatus: 'Semantic Engine Not Initialized',
+  initSemanticEngineButton: 'Initialize Semantic Engine',
+  reinitializeButton: 'Reinitialize',
+
+  // Model states
+  downloadingModelStatus: 'Downloading Model... {0}%',
+  switchingModelStatus: 'Switching Model...',
+  modelLoadedStatus: 'Model Loaded',
+  modelFailedStatus: 'Model Failed to Load',
+
+  // Model descriptions
+  lightweightModelDescription: 'Lightweight Multilingual Model',
+  betterThanSmallDescription: 'Slightly larger than e5-small, but better performance',
+  multilingualModelDescription: 'Multilingual Semantic Model',
+
+  // Performance levels
+  fastPerformance: 'Fast',
+  balancedPerformance: 'Balanced',
+  accuratePerformance: 'Accurate',
+
+  // Error messages
+  networkErrorMessage: 'Network connection error, please check network and retry',
+  modelCorruptedErrorMessage: 'Model file corrupted or incomplete, please retry download',
+  unknownErrorMessage: 'Unknown error, please check if your network can access HuggingFace',
+  permissionDeniedErrorMessage: 'Permission denied',
+  timeoutErrorMessage: 'Operation timed out',
+
+  // Data statistics
+  indexedPagesLabel: 'Indexed Pages',
+  indexSizeLabel: 'Index Size',
+  activeTabsLabel: 'Active Tabs',
+  vectorDocumentsLabel: 'Vector Documents',
+  cacheSizeLabel: 'Cache Size',
+  cacheEntriesLabel: 'Cache Entries',
+
+  // Data management
+  clearAllDataButton: 'Clear All Data',
+  clearAllCacheButton: 'Clear All Cache',
+  cleanExpiredCacheButton: 'Clean Expired Cache',
+  exportDataButton: 'Export Data',
+  importDataButton: 'Import Data',
+
+  // Dialog titles
+  confirmClearDataTitle: 'Confirm Clear Data',
+  settingsTitle: 'Settings',
+  aboutTitle: 'About',
+  helpTitle: 'Help',
+
+  // Dialog messages
+  clearDataWarningMessage:
+    'This operation will clear all indexed webpage content and vector data, including:',
+  clearDataList1: 'All webpage text content index',
+  clearDataList2: 'Vector embedding data',
+  clearDataList3: 'Search history and cache',
+  clearDataIrreversibleWarning:
+    'This operation is irreversible! After clearing, you need to browse webpages again to rebuild the index.',
+  confirmClearButton: 'Confirm Clear',
+
+  // Cache states
+  cacheDetailsLabel: 'Cache Details',
+  noCacheDataMessage: 'No cache data',
+  loadingCacheInfoStatus: 'Loading cache information...',
+  processingCacheStatus: 'Processing cache...',
+  expiredLabel: 'Expired',
+
+  // Browser integration
+  bookmarksBarLabel: 'Bookmarks Bar',
+  newTabLabel: 'New Tab',
+  currentPageLabel: 'Current Page',
+
+  // Accessibility
+  menuLabel: 'Menu',
+  navigationLabel: 'Navigation',
+  mainContentLabel: 'Main Content',
+
+  // Future features
+  languageSelectorLabel: 'Language',
+  themeLabel: 'Theme',
+  lightTheme: 'Light',
+  darkTheme: 'Dark',
+  autoTheme: 'Auto',
+  advancedSettingsLabel: 'Advanced Settings',
+  debugModeLabel: 'Debug Mode',
+  verboseLoggingLabel: 'Verbose Logging',
+
+  // Notifications
+  successNotification: 'Operation completed successfully',
+  warningNotification: 'Warning: Please review before proceeding',
+  infoNotification: 'Information',
+  configCopiedNotification: 'Configuration copied to clipboard',
+  dataClearedNotification: 'Data cleared successfully',
+
+  // Units
+  bytesUnit: 'bytes',
+  kilobytesUnit: 'KB',
+  megabytesUnit: 'MB',
+  gigabytesUnit: 'GB',
+  itemsUnit: 'items',
+  pagesUnit: 'pages',
+
+  // Legacy keys for backwards compatibility
+  nativeServerConfig: 'Native Server Configuration',
+  runningStatus: 'Running Status',
+  refreshStatus: 'Refresh Status',
+  lastUpdated: 'Last Updated:',
+  mcpServerConfig: 'MCP Server Configuration',
+  connectionPort: 'Connection Port',
+  connecting: 'Connecting...',
+  disconnect: 'Disconnect',
+  connect: 'Connect',
+  semanticEngine: 'Semantic Engine',
+  embeddingModel: 'Embedding Model',
+  retry: 'Retry',
+  indexDataManagement: 'Index Data Management',
+  clearing: 'Clearing...',
+  clearAllData: 'Clear All Data',
+  copyConfig: 'Copy Configuration',
+  serviceRunning: 'Service Running (Port: {0})',
+  connectedServiceNotStarted: 'Connected, Service Not Started',
+  serviceNotConnected: 'Service Not Connected',
+  detecting: 'Detecting...',
+  lightweightModel: 'Lightweight Multilingual Model',
+  betterThanSmall: 'Slightly larger than e5-small, but better performance',
+  multilingualModel: 'Multilingual Semantic Model',
+  fast: 'Fast',
+  balanced: 'Balanced',
+  accurate: 'Accurate',
+  semanticEngineReady: 'Semantic Engine Ready',
+  semanticEngineInitializing: 'Semantic Engine Initializing...',
+  semanticEngineInitFailed: 'Semantic Engine Initialization Failed',
+  semanticEngineNotInit: 'Semantic Engine Not Initialized',
+  downloadingModel: 'Downloading Model... {0}%',
+  switchingModel: 'Switching Model...',
+  networkError: 'Network connection error, please check network and retry',
+  modelCorrupted: 'Model file corrupted or incomplete, please retry download',
+  unknownError: 'Unknown error, please check if your network can access HuggingFace',
+  reinitialize: 'Reinitialize',
+  initializing: 'Initializing...',
+  initSemanticEngine: 'Initialize Semantic Engine',
+  indexedPages: 'Indexed Pages',
+  indexSize: 'Index Size',
+  activeTabs: 'Active Tabs',
+  vectorDocuments: 'Vector Documents',
+  confirmClearData: 'Confirm Clear Data',
+  clearDataWarning:
+    'This operation will clear all indexed webpage content and vector data, including:',
+  clearDataIrreversible:
+    'This operation is irreversible! After clearing, you need to browse webpages again to rebuild the index.',
+  confirmClear: 'Confirm Clear',
+  cancel: 'Cancel',
+  confirm: 'Confirm',
+  processing: 'Processing...',
+  modelCacheManagement: 'Model Cache Management',
+  cacheSize: 'Cache Size',
+  cacheEntries: 'Cache Entries',
+  cacheDetails: 'Cache Details',
+  noCacheData: 'No cache data',
+  loadingCacheInfo: 'Loading cache information...',
+  processingCache: 'Processing cache...',
+  cleaning: 'Cleaning...',
+  cleanExpiredCache: 'Clean Expired Cache',
+  clearAllCache: 'Clear All Cache',
+  expired: 'Expired',
+  bookmarksBar: 'Bookmarks Bar',
+};
+
+/**
+ * Safe i18n message getter with fallback support
+ * @param key Message key
+ * @param substitutions Optional substitution values
+ * @returns Localized message or fallback
+ */
+export function getMessage(key: string, substitutions?: string[]): string {
+  try {
+    // Check if Chrome extension APIs are available
+    if (typeof chrome !== 'undefined' && chrome.i18n && chrome.i18n.getMessage) {
+      const message = chrome.i18n.getMessage(key, substitutions);
+      if (message) {
+        return message;
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to get i18n message for key "${key}":`, error);
+  }
+
+  // Fallback to English messages
+  let fallback = fallbackMessages[key] || key;
+
+  // Handle substitutions in fallback messages
+  if (substitutions && substitutions.length > 0) {
+    substitutions.forEach((value, index) => {
+      fallback = fallback.replace(`{${index}}`, value);
+    });
+  }
+
+  return fallback;
+}
+
+/**
+ * Check if Chrome extension i18n APIs are available
+ */
+export function isI18nAvailable(): boolean {
+  try {
+    return (
+      typeof chrome !== 'undefined' && chrome.i18n && typeof chrome.i18n.getMessage === 'function'
+    );
+  } catch {
+    return false;
+  }
+}

--- a/app/chrome-extension/wxt.config.ts
+++ b/app/chrome-extension/wxt.config.ts
@@ -14,8 +14,9 @@ export default defineConfig({
   manifest: {
     // Use environment variable for the key, fallback to undefined if not set
     key: CHROME_EXTENSION_KEY,
-    name: 'chrome-mcp-server',
-    description: 'Exposes browser capabilities with your own chrome',
+    default_locale: 'zh_CN',
+    name: '__MSG_extensionName__',
+    description: '__MSG_extensionDescription__',
     permissions: [
       'nativeMessaging',
       'tabs',
@@ -60,6 +61,10 @@ export default defineConfig({
           {
             src: ['workers/*'],
             dest: 'workers',
+          },
+          {
+            src: '_locales/**/*',
+            dest: '_locales',
           },
         ],
       }) as any,


### PR DESCRIPTION
🚀 添加国际化（i18n）支持，增加英文语言包

简介
此 PR 为 MCP-Chrome 添加了国际化（i18n）支持，使用 Chrome 扩展标准的 \_locales/ 系统。所有 UI 界面中的硬编码文本都被替换为 message key，并新增了英文 (en) 语言文件，保留原有简体中文 (zh\_CN) 为默认语言。

包含的更改

* 添加 \_locales/en/messages.json，提供完整英文翻译
* 添加 \_locales/zh\_CN/messages.json，提取自原有中文文本
* 所有硬编码文本替换为 chrome.i18n.getMessage(...)
* 更新 manifest.json：
  · 设置 "default\_locale": "zh\_CN"
  · 使用 **MSG*...*\_ 替换 "name" 和 "description"
* 新增 "extensionDisplayName" 用于界面显示（与 "extensionName" 区分）

优点

* 根据用户浏览器语言自动切换 UI
* 若翻译缺失，可自动回退至中文
* 为未来支持其他语言（如法语、日语）打下基础

测试说明

* 确认扩展在英文浏览器环境下可正常加载和显示
* 验证语言切换与默认回退机制

备注

* 本更改不会影响现有简体中文用户的使用体验
* 如需支持更多语言，我愿意继续协助

-----------

🚀 Add Internationalization (i18n) Support with English Locale

Summary
This PR introduces internationalization (i18n) support to MCP-Chrome using the Chrome Extension \_locales/ system. All hardcoded UI text has been replaced with message keys, and an English (en) locale has been added alongside the existing Simplified Chinese (zh\_CN).

Changes Included

* Added \_locales/en/messages.json with complete English UI text
* Added \_locales/zh\_CN/messages.json extracted from existing Chinese text
* Replaced all hardcoded UI strings with chrome.i18n.getMessage(...)
* Updated manifest.json:
  · "default\_locale": "zh\_CN" (preserves behavior for current users)
  · Replaced "name" and "description" with **MSG*...*\_ keys
* Introduced "extensionDisplayName" for UI purposes (vs "extensionName" used in manifest)

Benefits

* UI automatically matches the user's browser/system language
* Graceful fallback to Chinese if translation is missing
* Enables future locales (French, Japanese, etc.) with minimal effort

Testing

* Validated that the extension loads and displays correctly in English

Notes

* This change does not alter any existing behavior for Chinese users
* Happy to assist with more language support in the future

Changes written by Claude, reviewed and verified by ChatGPT-4
