### PR TITLE
fix: unnecessary nested CallToolResult in response

### DIFF
--- a/app/native-server/src/mcp/register-tools.ts
+++ b/app/native-server/src/mcp/register-tools.ts
@@ -28,15 +28,19 @@ const handleToolCall = async (name: string, args: any): Promise<CallToolResult> 
       NativeMessageType.CALL_TOOL,
       30000, // 30秒超时
     );
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(response),
-        },
-      ],
-      isError: false,
-    };
+    if (response.status === 'success') {
+      return response.data;
+    } else {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error calling tool: ${response.error}`,
+          },
+        ],
+        isError: true,
+      };
+    }
   } catch (error: any) {
     return {
       content: [


### PR DESCRIPTION
Currently, the MCP server response data has unnecessary nested `CallToolResult`.

For example, when using `chrome_navigate`, here's the response from MCP Inspector. The `content.text.data` is actually another `CallToolResult` object.
```json
{
  "content": [
    {
      "type": "text",
      "text": "{\"status\":\"success\",\"message\":\"Tool executed successfully\",\"data\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"success\\\":true,\\\"message\\\":\\\"Activated existing tab\\\",\\\"tabId\\\":1914478698,\\\"windowId\\\":1914477818,\\\"url\\\":\\\"https://www.google.com/\\\"}\"}],\"isError\":false}}"
    }
  ],
  "isError": false
}
```

A bigger problem arises when calling tool fails. Let's use `chrome_navigate` again, if I don't provide url, `isError` is false in the json, which should be true.
```json
{
  "content": [
    {
      "type": "text",
      "text": "{\"status\":\"success\",\"message\":\"Tool executed successfully\",\"data\":{\"content\":[{\"type\":\"text\",\"text\":\"URL parameter is required when refresh is not true\"}],\"isError\":true}}"
    }
  ],
  "isError": false
}
```

After this change, for above two cases, the responses will be
```json
{
  "content": [
    {
      "type": "text",
      "text": "{\"success\":true,\"message\":\"Activated existing tab\",\"tabId\":1914478698,\"windowId\":1914477818,\"url\":\"https://www.google.com/\"}"
    }
  ],
  "isError": false
}
{
  "content": [
    {
      "type": "text",
      "text": "URL parameter is required when refresh is not true"
    }
  ],
  "isError": true
}
```