### PR TITLE
feat(i18n): Add Japanese (ja) localization

### DIFF
--- a/app/chrome-extension/_locales/ja/messages.json
+++ b/app/chrome-extension/_locales/ja/messages.json
@@ -53,8 +53,9 @@
   "serviceRunningStatus": {
     "message": "サービス実行中 (ポート: $1)",
     "placeholders": {
-      "1": {
-        "content": "$1"
+      "port": {
+        "content": "$1",
+        "example": "12306"
       }
     }
   },
@@ -133,8 +134,9 @@
   "downloadingModelStatus": {
     "message": "モデルをダウンロード中... $1%",
     "placeholders": {
-      "1": {
-        "content": "$1"
+      "progress": {
+        "content": "$1",
+        "example": "50"
       }
     }
   },

--- a/app/chrome-extension/_locales/ja/messages.json
+++ b/app/chrome-extension/_locales/ja/messages.json
@@ -1,0 +1,336 @@
+{
+  "extensionName": {
+    "message": "Chrome MCPサーバー"
+  },
+  "extensionDescription": {
+    "message": "自身のChromeブラウザの機能を外部に公開します"
+  },
+  "nativeServerConfigLabel": {
+    "message": "ネイティブサーバー設定"
+  },
+  "semanticEngineLabel": {
+    "message": "セマンティックエンジン"
+  },
+  "embeddingModelLabel": {
+    "message": "埋め込みモデル"
+  },
+  "indexDataManagementLabel": {
+    "message": "インデックスデータ管理"
+  },
+  "modelCacheManagementLabel": {
+    "message": "モデルキャッシュ管理"
+  },
+  "statusLabel": {
+    "message": "ステータス"
+  },
+  "runningStatusLabel": {
+    "message": "実行ステータス"
+  },
+  "connectionStatusLabel": {
+    "message": "接続ステータス"
+  },
+  "lastUpdatedLabel": {
+    "message": "最終更新:"
+  },
+  "connectButton": {
+    "message": "接続"
+  },
+  "disconnectButton": {
+    "message": "切断"
+  },
+  "connectingStatus": {
+    "message": "接続中..."
+  },
+  "connectedStatus": {
+    "message": "接続済み"
+  },
+  "disconnectedStatus": {
+    "message": "未接続"
+  },
+  "detectingStatus": {
+    "message": "検出中..."
+  },
+  "serviceRunningStatus": {
+    "message": "サービス実行中 (ポート: $1)",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "serviceNotConnectedStatus": {
+    "message": "サービス未接続"
+  },
+  "connectedServiceNotStartedStatus": {
+    "message": "接続済み、サービス未起動"
+  },
+  "mcpServerConfigLabel": {
+    "message": "MCPサーバー設定"
+  },
+  "connectionPortLabel": {
+    "message": "接続ポート"
+  },
+  "refreshStatusButton": {
+    "message": "ステータス更新"
+  },
+  "copyConfigButton": {
+    "message": "設定をコピー"
+  },
+  "retryButton": {
+    "message": "再試行"
+  },
+  "cancelButton": {
+    "message": "キャンセル"
+  },
+  "confirmButton": {
+    "message": "確認"
+  },
+  "saveButton": {
+    "message": "保存"
+  },
+  "closeButton": {
+    "message": "閉じる"
+  },
+  "resetButton": {
+    "message": "リセット"
+  },
+  "initializingStatus": {
+    "message": "初期化中..."
+  },
+  "processingStatus": {
+    "message": "処理中..."
+  },
+  "loadingStatus": {
+    "message": "読み込み中..."
+  },
+  "clearingStatus": {
+    "message": "クリア中..."
+  },
+  "cleaningStatus": {
+    "message": "クリーンアップ中..."
+  },
+  "downloadingStatus": {
+    "message": "ダウンロード中..."
+  },
+  "semanticEngineReadyStatus": {
+    "message": "セマンティックエンジン準備完了"
+  },
+  "semanticEngineInitializingStatus": {
+    "message": "セマンティックエンジン初期化中..."
+  },
+  "semanticEngineInitFailedStatus": {
+    "message": "セマンティックエンジンの初期化に失敗しました"
+  },
+  "semanticEngineNotInitStatus": {
+    "message": "セマンティックエンジン未初期化"
+  },
+  "initSemanticEngineButton": {
+    "message": "セマンティックエンジンを初期化"
+  },
+  "reinitializeButton": {
+    "message": "再初期化"
+  },
+  "downloadingModelStatus": {
+    "message": "モデルをダウンロード中... $1%",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "switchingModelStatus": {
+    "message": "モデルを切り替え中..."
+  },
+  "modelLoadedStatus": {
+    "message": "モデル読み込み完了"
+  },
+  "modelFailedStatus": {
+    "message": "モデルの読み込みに失敗しました"
+  },
+  "lightweightModelDescription": {
+    "message": "軽量多言語モデル"
+  },
+  "betterThanSmallDescription": {
+    "message": "e5-smallよりわずかに大きいが、性能は向上"
+  },
+  "multilingualModelDescription": {
+    "message": "多言語対応セマンティックモデル"
+  },
+  "fastPerformance": {
+    "message": "高速"
+  },
+  "balancedPerformance": {
+    "message": "バランス"
+  },
+  "accuratePerformance": {
+    "message": "高精度"
+  },
+  "networkErrorMessage": {
+    "message": "ネットワーク接続エラーです。ネットワークを確認して再試行してください"
+  },
+  "modelCorruptedErrorMessage": {
+    "message": "モデルファイルが破損しているか不完全です。再ダウンロードしてください"
+  },
+  "unknownErrorMessage": {
+    "message": "不明なエラーです。ネットワークがHuggingFaceにアクセスできるか確認してください"
+  },
+  "permissionDeniedErrorMessage": {
+    "message": "権限が拒否されました"
+  },
+  "timeoutErrorMessage": {
+    "message": "操作がタイムアウトしました"
+  },
+  "indexedPagesLabel": {
+    "message": "インデックス化されたページ"
+  },
+  "indexSizeLabel": {
+    "message": "インデックスサイズ"
+  },
+  "activeTabsLabel": {
+    "message": "アクティブなタブ"
+  },
+  "vectorDocumentsLabel": {
+    "message": "ベクトルドキュメント"
+  },
+  "cacheSizeLabel": {
+    "message": "キャッシュサイズ"
+  },
+  "cacheEntriesLabel": {
+    "message": "キャッシュエントリ"
+  },
+  "clearAllDataButton": {
+    "message": "全データをクリア"
+  },
+  "clearAllCacheButton": {
+    "message": "全キャッシュをクリア"
+  },
+  "cleanExpiredCacheButton": {
+    "message": "期限切れキャッシュをクリーンアップ"
+  },
+  "exportDataButton": {
+    "message": "データのエクスポート"
+  },
+  "importDataButton": {
+    "message": "データのインポート"
+  },
+  "confirmClearDataTitle": {
+    "message": "データクリアの確認"
+  },
+  "settingsTitle": {
+    "message": "設定"
+  },
+  "aboutTitle": {
+    "message": "情報"
+  },
+  "helpTitle": {
+    "message": "ヘルプ"
+  },
+  "clearDataWarningMessage": {
+    "message": "この操作は、インデックス化されたすべてのウェブページコンテンツとベクトルデータをクリアします。これには以下が含まれます："
+  },
+  "clearDataList1": {
+    "message": "すべてのウェブページテキストコンテンツインデックス"
+  },
+  "clearDataList2": {
+    "message": "ベクトル埋め込みデータ"
+  },
+  "clearDataList3": {
+    "message": "検索履歴とキャッシュ"
+  },
+  "clearDataIrreversibleWarning": {
+    "message": "この操作は元に戻せません！クリア後、再度ウェブページを閲覧してインデックスを再構築する必要があります。"
+  },
+  "confirmClearButton": {
+    "message": "クリアを確認"
+  },
+  "cacheDetailsLabel": {
+    "message": "キャッシュ詳細"
+  },
+  "noCacheDataMessage": {
+    "message": "キャッシュデータがありません"
+  },
+  "loadingCacheInfoStatus": {
+    "message": "キャッシュ情報を読み込み中..."
+  },
+  "processingCacheStatus": {
+    "message": "キャッシュを処理中..."
+  },
+  "expiredLabel": {
+    "message": "期限切れ"
+  },
+  "bookmarksBarLabel": {
+    "message": "ブックマークバー"
+  },
+  "newTabLabel": {
+    "message": "新しいタブ"
+  },
+  "currentPageLabel": {
+    "message": "現在のページ"
+  },
+  "menuLabel": {
+    "message": "メニュー"
+  },
+  "navigationLabel": {
+    "message": "ナビゲーション"
+  },
+  "mainContentLabel": {
+    "message": "メインコンテンツ"
+  },
+  "languageSelectorLabel": {
+    "message": "言語"
+  },
+  "themeLabel": {
+    "message": "テーマ"
+  },
+  "lightTheme": {
+    "message": "ライト"
+  },
+  "darkTheme": {
+    "message": "ダーク"
+  },
+  "autoTheme": {
+    "message": "自動"
+  },
+  "advancedSettingsLabel": {
+    "message": "詳細設定"
+  },
+  "debugModeLabel": {
+    "message": "デバッグモード"
+  },
+  "verboseLoggingLabel": {
+    "message": "詳細ロギング"
+  },
+  "successNotification": {
+    "message": "操作が正常に完了しました"
+  },
+  "warningNotification": {
+    "message": "警告：続行する前に確認してください"
+  },
+  "infoNotification": {
+    "message": "情報"
+  },
+  "configCopiedNotification": {
+    "message": "設定がクリップボードにコピーされました"
+  },
+  "dataClearedNotification": {
+    "message": "データが正常にクリアされました"
+  },
+  "bytesUnit": {
+    "message": "バイト"
+  },
+  "kilobytesUnit": {
+    "message": "KB"
+  },
+  "megabytesUnit": {
+    "message": "MB"
+  },
+  "gigabytesUnit": {
+    "message": "GB"
+  },
+  "itemsUnit": {
+    "message": "項目"
+  },
+  "pagesUnit": {
+    "message": "ページ"
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces Japanese (`ja`) localization to the Chrome MCP Server extension, enabling Japanese-speaking users to use the interface in their native language.

## What's Changed

- Added `_locales/ja/messages.json` with complete translations for all existing keys.
- Translated UI text into natural Japanese.
- Maintained common technical terms (e.g., "Server", "Cache", "Port") in Katakana or English to align with standard usage in the Japanese IT context.
- Corrected the structure of `placeholders` objects to align with the source `en/messages.json` format.

## Testing Done

The following validation steps have been successfully completed to ensure the quality and correctness of the localization.

- **Key Integrity Verification**: Ensured that the localization keys in `ja/messages.json` perfectly match the source `en/messages.json`. The following command returned no differences.
  ```bash
  diff <(jq -r 'keys_unsorted[]' app/chrome-extension/_locales/en/messages.json | sort) <(jq -r 'keys_unsorted[]' app/chrome-extension/_locales/ja/messages.json | sort)
  
- JSON Syntax Validation: Confirmed that ja/messages.json is a well-formed JSON file. The following command completed without any errors.

```:bash
jq . app/chrome-extension/_locales/ja/messages.json > /dev/null
```

- Placeholder Preservation Check: Confirmed that message placeholders (e.g., $1) and their corresponding named objects ("port", "progress") are correctly maintained in the translated strings, matching the structure of the English source.

```:bash
grep -B 2 -A 3 '"placeholders"' app/chrome-extension/_locales/ja/messages.json
```

- UI Verification: Manually tested the extension in a live browser environment.
1. Set the browser's primary language to Japanese.
2. Loaded the unpacked extension in developer mode.
3. Opened the popup and verified that all UI text elements (titles, buttons, status messages) are correctly displayed in Japanese without layout issues or character encoding problems (文字化け).

## Related Issues
Addresses the need for broader language support in the Chrome MCP Server extension.

