### PR TITLE
fix: add missing MCP protocol handlers to prevent Claude Desktop crashes

### DIFF
--- a/app/native-server/src/mcp/mcp-server-stdio.ts
+++ b/app/native-server/src/mcp/mcp-server-stdio.ts
@@ -6,6 +6,8 @@ import {
   CallToolRequestSchema,
   CallToolResult,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListPromptsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { TOOL_SCHEMAS } from 'chrome-mcp-shared';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -40,6 +42,8 @@ export const getStdioMcpServer = () => {
     {
       capabilities: {
         tools: {},
+        resources: {},
+        prompts: {},
       },
     },
   );
@@ -77,6 +81,12 @@ export const setupTools = (server: Server) => {
   server.setRequestHandler(CallToolRequestSchema, async (request) =>
     handleToolCall(request.params.name, request.params.arguments || {}),
   );
+
+  // List resources handler - REQUIRED BY MCP PROTOCOL
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+
+  // List prompts handler - REQUIRED BY MCP PROTOCOL
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [] }));
 };
 
 const handleToolCall = async (name: string, args: any): Promise<CallToolResult> => {


### PR DESCRIPTION
## Problem
Claude Desktop crashes with 'dialog module can only be used after app is ready' error when connecting to MCP servers that don't implement the full MCP protocol specification.

## Solution
- Add ListResourcesRequestSchema and ListPromptsRequestSchema imports
- Implement required resources and prompts capabilities in server setup  
- Add empty handlers for list_resources and list_prompts requests

## Testing
- Prevents Claude Desktop Electron crash on startup
- MCP server now properly implements required protocol handlers
- Single file change to `app/native-server/src/mcp/mcp-server-stdio.ts`

## Impact
This fixes a critical issue where users experience crashes when trying to use the Chrome MCP Server with Claude Desktop.