### PR TITLE
feat(native-server): add Chromium browser support

### DIFF
--- a/app/native-server/README.md
+++ b/app/native-server/README.md
@@ -5,6 +5,7 @@
 ## 功能特性
 
 - 通过Chrome Native Messaging协议与Chrome扩展进行双向通信
+- **支持多浏览器**: Chrome 和 Chromium (包括 Linux、macOS 和 Windows)
 - 提供RESTful API服务
 - 完全使用TypeScript开发
 - 包含完整的测试套件
@@ -14,7 +15,7 @@
 
 ### 前置条件
 
-- Node.js 14+ 
+- Node.js 14+
 - npm 6+
 
 ### 安装
@@ -28,11 +29,14 @@ npm install
 ### 开发
 
 1. 本地构建注册native server
+
 ```bash
 cd app/native-server
 npm run dev
 ```
+
 2. 启动chrome extension
+
 ```bash
 cd app/chrome-extension
 npm run dev
@@ -46,10 +50,43 @@ npm run build
 
 ### 注册Native Messaging主机
 
-全局安装后会自动注册
+#### 自动检测并注册所有已安装的浏览器
+
+```bash
+mcp-chrome-bridge register --detect
+```
+
+#### 注册特定浏览器
+
+```bash
+# 仅注册 Chrome
+mcp-chrome-bridge register --browser chrome
+
+# 仅注册 Chromium
+mcp-chrome-bridge register --browser chromium
+
+# 注册所有支持的浏览器
+mcp-chrome-bridge register --browser all
+```
+
+#### 全局安装（会自动注册检测到的浏览器）
+
 ```bash
 npm i -g mcp-chrome-bridge
 ```
+
+#### 浏览器支持
+
+| 浏览器        | Linux | macOS | Windows |
+| ------------- | ----- | ----- | ------- |
+| Google Chrome | ✓     | ✓     | ✓       |
+| Chromium      | ✓     | ✓     | ✓       |
+
+注册位置：
+
+- **Linux**: `~/.config/[browser-name]/NativeMessagingHosts/`
+- **macOS**: `~/Library/Application Support/[Browser]/NativeMessagingHosts/`
+- **Windows**: `%APPDATA%\[Browser]\NativeMessagingHosts\`
 
 ### 与Chrome扩展集成
 
@@ -66,13 +103,13 @@ function startServer() {
     console.log('已连接到Native Messaging主机');
     return;
   }
-  
+
   try {
     nativePort = chrome.runtime.connectNative('com.yourcompany.fastify_native_host');
-    
-    nativePort.onMessage.addListener(message => {
+
+    nativePort.onMessage.addListener((message) => {
       console.log('收到Native消息:', message);
-      
+
       if (message.type === 'started') {
         serverRunning = true;
         console.log(`服务已启动，端口: ${message.payload.port}`);
@@ -83,16 +120,15 @@ function startServer() {
         console.error('Native错误:', message.payload.message);
       }
     });
-    
+
     nativePort.onDisconnect.addListener(() => {
       console.log('Native连接断开:', chrome.runtime.lastError);
       nativePort = null;
       serverRunning = false;
     });
-    
+
     // 启动服务器
     nativePort.postMessage({ type: 'start', payload: { port: 3000 } });
-    
   } catch (error) {
     console.error('启动Native Messaging时出错:', error);
   }

--- a/app/native-server/src/scripts/browser-config.ts
+++ b/app/native-server/src/scripts/browser-config.ts
@@ -1,0 +1,270 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { HOST_NAME } from './constant';
+
+export enum BrowserType {
+  CHROME = 'chrome',
+  CHROMIUM = 'chromium',
+}
+
+export interface BrowserConfig {
+  type: BrowserType;
+  displayName: string;
+  userManifestPath: string;
+  systemManifestPath: string;
+  registryKey?: string; // Windows only
+  systemRegistryKey?: string; // Windows only
+}
+
+/**
+ * Get the user-level manifest path for a specific browser
+ */
+function getUserManifestPathForBrowser(browser: BrowserType): string {
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join(appData, 'Google', 'Chrome', 'NativeMessagingHosts', `${HOST_NAME}.json`);
+      case BrowserType.CHROMIUM:
+        return path.join(appData, 'Chromium', 'NativeMessagingHosts', `${HOST_NAME}.json`);
+      default:
+        return path.join(appData, 'Google', 'Chrome', 'NativeMessagingHosts', `${HOST_NAME}.json`);
+    }
+  } else if (platform === 'darwin') {
+    const home = os.homedir();
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join(
+          home,
+          'Library',
+          'Application Support',
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      case BrowserType.CHROMIUM:
+        return path.join(
+          home,
+          'Library',
+          'Application Support',
+          'Chromium',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      default:
+        return path.join(
+          home,
+          'Library',
+          'Application Support',
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+    }
+  } else {
+    // Linux
+    const home = os.homedir();
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join(
+          home,
+          '.config',
+          'google-chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      case BrowserType.CHROMIUM:
+        return path.join(home, '.config', 'chromium', 'NativeMessagingHosts', `${HOST_NAME}.json`);
+      default:
+        return path.join(
+          home,
+          '.config',
+          'google-chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+    }
+  }
+}
+
+/**
+ * Get the system-level manifest path for a specific browser
+ */
+function getSystemManifestPathForBrowser(browser: BrowserType): string {
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join(
+          programFiles,
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      case BrowserType.CHROMIUM:
+        return path.join(programFiles, 'Chromium', 'NativeMessagingHosts', `${HOST_NAME}.json`);
+      default:
+        return path.join(
+          programFiles,
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+    }
+  } else if (platform === 'darwin') {
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join(
+          '/Library',
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      case BrowserType.CHROMIUM:
+        return path.join(
+          '/Library',
+          'Application Support',
+          'Chromium',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+      default:
+        return path.join(
+          '/Library',
+          'Google',
+          'Chrome',
+          'NativeMessagingHosts',
+          `${HOST_NAME}.json`,
+        );
+    }
+  } else {
+    // Linux
+    switch (browser) {
+      case BrowserType.CHROME:
+        return path.join('/etc', 'opt', 'chrome', 'native-messaging-hosts', `${HOST_NAME}.json`);
+      case BrowserType.CHROMIUM:
+        return path.join('/etc', 'chromium', 'native-messaging-hosts', `${HOST_NAME}.json`);
+      default:
+        return path.join('/etc', 'opt', 'chrome', 'native-messaging-hosts', `${HOST_NAME}.json`);
+    }
+  }
+}
+
+/**
+ * Get Windows registry keys for a browser
+ */
+function getRegistryKeys(browser: BrowserType): { user: string; system: string } | undefined {
+  if (os.platform() !== 'win32') return undefined;
+
+  const browserPaths: Record<BrowserType, { user: string; system: string }> = {
+    [BrowserType.CHROME]: {
+      user: `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${HOST_NAME}`,
+      system: `HKLM\\Software\\Google\\Chrome\\NativeMessagingHosts\\${HOST_NAME}`,
+    },
+    [BrowserType.CHROMIUM]: {
+      user: `HKCU\\Software\\Chromium\\NativeMessagingHosts\\${HOST_NAME}`,
+      system: `HKLM\\Software\\Chromium\\NativeMessagingHosts\\${HOST_NAME}`,
+    },
+  };
+
+  return browserPaths[browser];
+}
+
+/**
+ * Get browser configuration
+ */
+export function getBrowserConfig(browser: BrowserType): BrowserConfig {
+  const registryKeys = getRegistryKeys(browser);
+
+  return {
+    type: browser,
+    displayName: browser.charAt(0).toUpperCase() + browser.slice(1),
+    userManifestPath: getUserManifestPathForBrowser(browser),
+    systemManifestPath: getSystemManifestPathForBrowser(browser),
+    registryKey: registryKeys?.user,
+    systemRegistryKey: registryKeys?.system,
+  };
+}
+
+/**
+ * Detect installed browsers on the system
+ */
+export function detectInstalledBrowsers(): BrowserType[] {
+  const detectedBrowsers: BrowserType[] = [];
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    // Check Windows registry for installed browsers
+    const browsers: Array<{ type: BrowserType; registryPath: string }> = [
+      { type: BrowserType.CHROME, registryPath: 'HKLM\\SOFTWARE\\Google\\Chrome' },
+      { type: BrowserType.CHROMIUM, registryPath: 'HKLM\\SOFTWARE\\Chromium' },
+    ];
+
+    for (const browser of browsers) {
+      try {
+        execSync(`reg query "${browser.registryPath}" 2>nul`, { stdio: 'pipe' });
+        detectedBrowsers.push(browser.type);
+      } catch {
+        // Browser not installed
+      }
+    }
+  } else if (platform === 'darwin') {
+    // Check macOS Applications folder
+    const browsers: Array<{ type: BrowserType; appPath: string }> = [
+      { type: BrowserType.CHROME, appPath: '/Applications/Google Chrome.app' },
+      { type: BrowserType.CHROMIUM, appPath: '/Applications/Chromium.app' },
+    ];
+
+    for (const browser of browsers) {
+      if (fs.existsSync(browser.appPath)) {
+        detectedBrowsers.push(browser.type);
+      }
+    }
+  } else {
+    // Check Linux paths using which command
+    const browsers: Array<{ type: BrowserType; commands: string[] }> = [
+      { type: BrowserType.CHROME, commands: ['google-chrome', 'google-chrome-stable'] },
+      { type: BrowserType.CHROMIUM, commands: ['chromium', 'chromium-browser'] },
+    ];
+
+    for (const browser of browsers) {
+      for (const cmd of browser.commands) {
+        try {
+          execSync(`which ${cmd} 2>/dev/null`, { stdio: 'pipe' });
+          detectedBrowsers.push(browser.type);
+          break; // Found one command, no need to check others
+        } catch {
+          // Command not found
+        }
+      }
+    }
+  }
+
+  return detectedBrowsers;
+}
+
+/**
+ * Get all supported browser configs
+ */
+export function getAllBrowserConfigs(): BrowserConfig[] {
+  return Object.values(BrowserType).map((browser) => getBrowserConfig(browser));
+}
+
+/**
+ * Parse browser type from string
+ */
+export function parseBrowserType(browserStr: string): BrowserType | undefined {
+  const normalized = browserStr.toLowerCase();
+  return Object.values(BrowserType).find((type) => type === normalized);
+}


### PR DESCRIPTION
## Summary
- Adds support for Chromium browser alongside Chrome
- Implements automatic browser detection
- Adds CLI options for browser selection

## Problem
Users with Chromium had to manually copy Native Messaging manifest files after each npm update. This was reported in issue #81 where Linux users noted that Chromium uses `.config/chromium` instead of `.config/google-chrome`.

## Solution
This PR adds multi-browser support to the native-server package:

### Features Added
- **Browser Detection**: Automatically detects installed browsers (Chrome and Chromium)
- **Multi-Browser Registration**: Registers Native Messaging hosts for both browsers
- **CLI Options**: 
  - `--browser <chrome|chromium|all>`: Register for specific browser
  - `--detect`: Auto-detect installed browsers

### Supported Platforms
| Browser | Linux | macOS | Windows |
|---------|-------|-------|---------|
| Google Chrome | ✓ | ✓ | ✓ |
| Chromium | ✓ | ✓ | ✓ |

## Test Plan
- [x] Tested browser detection on Linux with Chromium
- [x] Verified manifest creation in correct directories
- [x] Tested `--browser` and `--detect` CLI options
- [x] Confirmed backward compatibility with existing Chrome installations
- [ ] Test on macOS
- [ ] Test on Windows

## Related Issues
Fixes #81

🤖 Generated with [Claude Code](https://claude.ai/code)