### PR TITLE
docs: fix incorrect CLI version flag in documentation

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,9 +1,13 @@
 # 🚀 Installation and Connection Issues
+
 ### If Connection Fails After Clicking the Connect Button on the Extension
+
 1. **Check if mcp-chrome-bridge is installed successfully**, ensure it's globally installed
+
 ```bash
-mcp-chrome-bridge -v
+mcp-chrome-bridge -V
 ```
+
 <img width="612" alt="Screenshot 2025-06-11 15 09 57" src="https://github.com/user-attachments/assets/59458532-e6e1-457c-8c82-3756a5dbb28e" />
 
 2. **Check if the manifest file is in the correct directory**
@@ -15,14 +19,14 @@ Mac path: /Users/xxx/Library/Application\ Support/Google/Chrome/NativeMessagingH
 If the npm package is installed correctly, a file named `com.chromemcp.nativehost.json` should be generated in this directory
 
 3. **Check if there are logs in the npm package installation directory**
-You need to check your installation path (if unclear, open the manifest file in step 2, the path field shows the installation directory). For example, if the installation path is as follows, check the log contents:
+   You need to check your installation path (if unclear, open the manifest file in step 2, the path field shows the installation directory). For example, if the installation path is as follows, check the log contents:
 
 C:\Users\admin\AppData\Local\nvm\v20.19.2\node_modules\mcp-chrome-bridge\dist\logs
 
 <img width="804" alt="Screenshot 2025-06-11 15 09 41" src="https://github.com/user-attachments/assets/ce7b7c94-7c84-409a-8210-c9317823aae1" />
 
 4. **Check if you have execution permissions**
-You need to check your installation path (if unclear, open the manifest file in step 2, the path field shows the installation directory). For example, if the Mac installation path is as follows:
+   You need to check your installation path (if unclear, open the manifest file in step 2, the path field shows the installation directory). For example, if the Mac installation path is as follows:
 
 `xxx/node_modules/mcp-chrome-bridge/dist/run_host.sh`
 

--- a/docs/TROUBLESHOOTING_zh.md
+++ b/docs/TROUBLESHOOTING_zh.md
@@ -9,12 +9,14 @@
 1. npm包全局安装后，确认清单文件com.chromemcp.nativehost.json的位置，里面有一个**path**字段，指向的是一个启动脚本:
 
 1.1 **检查mcp-chrome-bridge是否安装成功**，确保是**全局安装**的
+
 ```bash
-mcp-chrome-bridge -v
+mcp-chrome-bridge -V
 ```
+
 <img width="612" alt="截屏2025-06-11 15 09 57" src="https://github.com/user-attachments/assets/59458532-e6e1-457c-8c82-3756a5dbb28e" />
 
- 1.2 **检查清单文件是否已放在正确目录**
+1.2 **检查清单文件是否已放在正确目录**
 
 windows路径：C:\Users\xxx\AppData\Roaming\Google\Chrome\NativeMessagingHosts
 
@@ -28,11 +30,10 @@ mac路径： /Users/xxx/Library/Application\ Support/Google/Chrome/NativeMessagi
   "description": "Node.js Host for Browser Bridge Extension",
   "path": "/Users/xxx/Library/pnpm/global/5/.pnpm/mcp-chrome-bridge@1.0.23/node_modules/mcp-chrome-bridge/dist/run_host.sh",
   "type": "stdio",
-  "allowed_origins": [
-    "chrome-extension://hbdgbgagpkpjffpklnamcljpakneikee/"
-  ]
+  "allowed_origins": ["chrome-extension://hbdgbgagpkpjffpklnamcljpakneikee/"]
 }
 ```
+
 > 如果发现没有此清单文件，可以尝试命令行执行：`mcp-chrome-bridge register`
 
 2. Chrome浏览器会找到上面的清单文件指向的脚本路径来执行该脚本，同时会在/Users/xxx/Library/pnpm/global/5/.pnpm/mcp-chrome-bridge@1.0.23/node_modules/mcp-chrome-bridge/dist/（windows的自行查看清单文件对应的目录）下生成logs文件夹，里面会记录日志
@@ -43,13 +44,12 @@ C:\Users\admin\AppData\Local\nvm\v20.19.2\node_modules\mcp-chrome-bridge\dist\lo
 
 3. 一般失败的原因就是两种
 
-3.1. run_host.sh(windows是run_host.bat)没有执行权限：此时你可以自行赋予权限，参考：https://github.com/hangwin/mcp-chrome/issues/22#issuecomment-2990636930。  脚本路径在上述的清单文件可以查看
+3.1. run_host.sh(windows是run_host.bat)没有执行权限：此时你可以自行赋予权限，参考：https://github.com/hangwin/mcp-chrome/issues/22#issuecomment-2990636930。 脚本路径在上述的清单文件可以查看
 
 3.2. 脚本找不到node，因为你可能电脑上装了不同版本的node，脚本确认不了你把npm包装在哪个node底下了，不同的人可能用了不同的node版本管理工具，导致找不到，
-参考：https://github.com/hangwin/mcp-chrome/issues/29#issuecomment-3003513940  （这个点目前正在优化中）
+参考：https://github.com/hangwin/mcp-chrome/issues/29#issuecomment-3003513940 （这个点目前正在优化中）
 
 3.3 如果排除了以上两种原因都不行，则查看日志目录的日志，然后提issue
-
 
 #### 工具执行超时
 
@@ -58,7 +58,3 @@ C:\Users\admin\AppData\Local\nvm\v20.19.2\node_modules\mcp-chrome-bridge\dist\lo
 #### 效果问题
 
 不同的agent，不同的模型使用工具的效果是不一样的，这些都需要你自行尝试，我更推荐用聪明的agent，比如augment，claude code等等...
-
-
-
-

--- a/docs/WINDOWS_INSTALL_zh.md
+++ b/docs/WINDOWS_INSTALL_zh.md
@@ -18,12 +18,11 @@ npm install -g mcp-chrome-bridge
 ```
 
 3. **加载 Chrome 扩展**
-
    - 打开 Chrome 并访问 `chrome://extensions/`
    - 启用"开发者模式"
    - 点击"加载已解压的扩展程序"，选择 `your/dowloaded/extension/folder`
    - 点击插件图标打开插件，点击连接即可看到mcp的配置
-<img width="475" alt="截屏2025-06-09 15 52 06" src="https://github.com/user-attachments/assets/241e57b8-c55f-41a4-9188-0367293dc5bc" />
+     <img width="475" alt="截屏2025-06-09 15 52 06" src="https://github.com/user-attachments/assets/241e57b8-c55f-41a4-9188-0367293dc5bc" />
 
 4. **在 CherryStudio 中使用**
 
@@ -53,8 +52,9 @@ npm install -g mcp-chrome-bridge
 1. **检查mcp-chrome-bridge是否安装成功**，确保是全局安装的
 
 ```bash
-mcp-chrome-bridge -v
+mcp-chrome-bridge -V
 ```
+
 <img width="612" alt="截屏2025-06-11 15 09 57" src="https://github.com/user-attachments/assets/59458532-e6e1-457c-8c82-3756a5dbb28e" />
 
 2. **检查清单文件是否已放在正确目录**
@@ -66,6 +66,3 @@ mcp-chrome-bridge -v
 具体要看你的安装路径（如果不清楚，可以打开第2步的清单文件，里面的path就是安装目录），比如安装路径如下：看下日志的内容
 C:\Users\admin\AppData\Local\nvm\v20.19.2\node_modules\mcp-chrome-bridge\dist\logs
 <img width="804" alt="截屏2025-06-11 15 09 41" src="https://github.com/user-attachments/assets/ce7b7c94-7c84-409a-8210-c9317823aae1" />
-
-
-


### PR DESCRIPTION
This PR corrects a CLI usage example in the documentation by changing the version flag from -v to -V for mcp-chrome-bridge, which resolves an execution error.

> Note: Additional formatting changes in the Markdown file were automatically applied by Prettier, based on the project's .prettierrc.json configuration. These changes were not manually introduced and do not affect the content or semantics of the documentation.