### PR TITLE
Add Claude env loading in host scripts and docs

### DIFF
--- a/app/chrome-extension/common/agent-models.ts
+++ b/app/chrome-extension/common/agent-models.ts
@@ -28,26 +28,26 @@ export type AgentCliType = 'claude' | 'codex' | 'cursor' | 'qwen' | 'glm';
 
 export const CLAUDE_MODELS: ModelDefinition[] = [
   {
-    id: 'claude-sonnet-4-5-20250929',
+    id: 'sonnet',
     name: 'Claude Sonnet 4.5',
     description: 'Balanced model with large context window',
     supportsImages: true,
   },
   {
-    id: 'claude-opus-4-5-20251101',
+    id: 'opus',
     name: 'Claude Opus 4.5',
     description: 'Strongest reasoning model',
     supportsImages: true,
   },
   {
-    id: 'claude-haiku-4-5-20251001',
+    id: 'haiku',
     name: 'Claude Haiku 4.5',
     description: 'Fast and cost-efficient',
     supportsImages: true,
   },
 ];
 
-export const CLAUDE_DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+export const CLAUDE_DEFAULT_MODEL = 'sonnet';
 
 // ============================================================
 // Codex Models

--- a/app/native-server/src/agent/engines/claude.ts
+++ b/app/native-server/src/agent/engines/claude.ts
@@ -108,7 +108,7 @@ export class ClaudeEngine implements AgentEngine {
 
     // Resolve model
     const resolvedModel =
-      model?.trim() || process.env.CLAUDE_DEFAULT_MODEL || 'claude-sonnet-4-20250514';
+      model?.trim() || process.env.CLAUDE_DEFAULT_MODEL || 'sonnet';
 
     // State management
     const stderrBuffer: string[] = [];

--- a/app/native-server/src/scripts/run_host.bat
+++ b/app/native-server/src/scripts/run_host.bat
@@ -176,6 +176,18 @@ for %%I in ("%NODE_EXEC%") do set "NODE_BIN_DIR=%%~dpI"
 if defined PATH (set "PATH=%NODE_BIN_DIR%;%PATH%") else (set "PATH=%NODE_BIN_DIR%")
 echo Added %NODE_BIN_DIR% to PATH >> "%WRAPPER_LOG%"
 
+REM Load env from Claude Code
+set "CLAUDE_SETTINGS=%USERPROFILE%\.claude\settings.json"
+if not exist "%CLAUDE_SETTINGS%" goto after_claude_env
+
+setlocal DisableDelayedExpansion
+for /f "usebackq delims=" %%L in (`"%NODE_EXEC%" -e "const fs=require('fs'); const path=process.env.USERPROFILE + '\\\\.claude\\\\settings.json'; if(!fs.existsSync(path)) process.exit(0); const json=JSON.parse(fs.readFileSync(path,'utf8')); const env=json.env||{}; const caret=String.fromCharCode(94); const esc=(s)=>String(s).replace(/%%/g,'%%%%').replace(/&/g,caret+'&').replace(/\|/g,caret+'|').replace(/</g,caret+'<').replace(/>/g,caret+'>').replace(/\"/g,caret+'\"').replace(new RegExp(caret,'g'),caret+caret); for (const [k,v] of Object.entries(env)) { console.log('set "'+k+'='+esc(v)+'"'); }"
+`) do (
+    endlocal & call %%L & setlocal DisableDelayedExpansion
+)
+endlocal
+:after_claude_env
+
 REM Log Claude Code Router (CCR) related env vars for debugging
 REM These are set via System Properties or PowerShell profile
 if defined ANTHROPIC_BASE_URL (

--- a/app/native-server/src/scripts/run_host.sh
+++ b/app/native-server/src/scripts/run_host.sh
@@ -252,6 +252,27 @@ NODE_BIN_DIR="$(dirname "${NODE_EXEC}")"
 export PATH="${NODE_BIN_DIR}${PATH:+:${PATH}}"
 echo "Added ${NODE_BIN_DIR} to PATH" >> "${WRAPPER_LOG}"
 
+
+# Load Claude env variables from settings.json
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+[ -f "$CLAUDE_SETTINGS" ] || return 0
+
+eval "$(
+  ${NODE_EXEC} -e '
+    const fs = require("fs");
+    const path = process.env.HOME + "/.claude/settings.json";
+    const json = JSON.parse(fs.readFileSync(path, "utf8"));
+    const env = json.env || {};
+
+    for (const [k, v] of Object.entries(env)) {
+      const val = String(v)
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, "\\\"");
+      console.log(`export ${k}="${val}"`);
+    }
+  '
+)"
+
 # Log Claude Code Router (CCR) related env vars for debugging
 # These are set by `eval "$(ccr activate)"` or in shell profile
 if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then

--- a/docs/VisualEditor.md
+++ b/docs/VisualEditor.md
@@ -45,3 +45,25 @@ Simply click an element and say, _"Make this bigger"_ or _"Change the background
     <img src="https://img.youtube.com/vi/76_DsUU7aHs/maxresdefault.jpg" alt="Interactive Sizing & Layout Adjustment" style="width:100%; max-width:600px;">
   </a>
 </div>
+
+### Claude Code Debug
+If your Claude Code is not using Anthropic’s official models (for example Deepseek/Kimi/GLM/Minimax), you may encounter 400 errors. There are two solutions:
+
+1. Add environment variables such as ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL.
+
+2. Configure the `env` field in `~/.claude/settings.json`. Example:
+
+```settings.json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-***",
+    "ANTHROPIC_BASE_URL": "https://***/anthropic",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "***",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "***",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "***",
+    "ANTHROPIC_MODEL": "***"
+  }
+}
+```
+
+Either option is fine. After configuring, run `pkill -TERM -f "mcp-chrome-bridge/dist/index.js"` to kill the bridge process; it will automatically restart and load the new environment variables.

--- a/docs/VisualEditor_zh.md
+++ b/docs/VisualEditor_zh.md
@@ -42,3 +42,25 @@
     <img src="https://img.youtube.com/vi/76_DsUU7aHs/maxresdefault.jpg" alt="Interactive Sizing & Layout Adjustment" style="width:100%; max-width:600px;">
   </a>
 </div>
+
+### Claude Code Debug
+如果你的 Claude Code 不是在使用 Anthropic 的官方模型（比如用的 Deepseek/Kimi/GLM/Minimax），使用 Claude Code 时很可能会遇到 400 报错。有 2 个解决方案：
+
+1. 在环境变量中添加 ANTHROPIC_AUTH_TOKEN 和 ANTHROPIC_BASE_URL 等环境变量的值。
+
+2. 在 `~/.claude/settings.json` 文件中配置 `env` 字段。文件示例：
+
+```settings.json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-***",
+    "ANTHROPIC_BASE_URL": "https://***/anthropic",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "***",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "***",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "***",
+    "ANTHROPIC_MODEL": "***"
+  }
+}
+```
+
+以上 2 个方案选其一即可。配置完成后，执行 `pkill -TERM -f "mcp-chrome-bridge/dist/index.js"` 杀掉 bridge 进程，该进程会自动重启并读取你新增的环境变量。


### PR DESCRIPTION
For users who are not using the models from anthropic in Claude Code, their configs are most likely stored in `~/.claude/settings.json`, which will prevent the Claude Agent SDK from reading the configuration properly, causing the Claude Code in VisualEditor to not work correctly.

This PR fixes this issue and adds instructions in the documentation.

I tested it on the Mac system, but I don't have a Windows system, so I'm not sure if `run_sh.bat` (which GPT-5.2-Codex helped me write) can work properly.