### PR TITLE
fix(native-server): use semicolon to join PowerShell statements

### DIFF
--- a/app/native-server/src/agent/directory-picker.ts
+++ b/app/native-server/src/agent/directory-picker.ts
@@ -92,8 +92,8 @@ async function openWindowsPicker(title: string): Promise<DirectoryPickerResult> 
     }
   `;
 
-  // Escape for command line
-  const escapedScript = psScript.replace(/"/g, '\\"').replace(/\n/g, ' ');
+  // Escape for command line - use semicolon to separate PowerShell statements
+  const escapedScript = psScript.replace(/"/g, '\\"').replace(/\n\s*/g, '; ');
 
   try {
     const { stdout } = await execAsync(


### PR DESCRIPTION
## Summary
- Replace space with semicolon when joining multiline PowerShell script to prevent syntax errors in directory picker

## Problem
When multiline PowerShell commands are joined with spaces, PowerShell fails to parse them correctly, causing the directory picker to fail on Windows.

## Solution
Use semicolon (`;`) as a statement separator instead of space when joining the script lines.