### PR TITLE
fix: support multiple concurrent MCP client connections

### DIFF
--- a/app/native-server/src/mcp/mcp-server.ts
+++ b/app/native-server/src/mcp/mcp-server.ts
@@ -1,13 +1,8 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { setupTools } from './register-tools';
 
-export let mcpServer: Server | null = null;
-
-export const getMcpServer = () => {
-  if (mcpServer) {
-    return mcpServer;
-  }
-  mcpServer = new Server(
+export const createMcpServer = () => {
+  const server = new Server(
     {
       name: 'ChromeMcpServer',
       version: '1.0.0',
@@ -19,6 +14,6 @@ export const getMcpServer = () => {
     },
   );
 
-  setupTools(mcpServer);
-  return mcpServer;
+  setupTools(server);
+  return server;
 };

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -22,7 +22,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { getMcpServer } from '../mcp/mcp-server';
+import { createMcpServer } from '../mcp/mcp-server';
 import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
@@ -181,8 +181,8 @@ export class Server {
           this.transportsMap.delete(transport.sessionId);
         });
 
-        const server = getMcpServer();
-        await server.connect(transport);
+        const mcpServer = createMcpServer();
+        await mcpServer.connect(transport);
 
         reply.raw.write(':\n\n');
       } catch (error) {
@@ -235,7 +235,8 @@ export class Server {
             this.transportsMap.delete(transport.sessionId);
           }
         };
-        await getMcpServer().connect(transport);
+        const mcpServer = createMcpServer();
+        await mcpServer.connect(transport);
       } else {
         reply.code(HTTP_STATUS.BAD_REQUEST).send({ error: ERROR_MESSAGES.INVALID_MCP_REQUEST });
         return;


### PR DESCRIPTION
## Summary

- The MCP `Server` (Protocol) instance was a **singleton** shared across all sessions. When a second client sent an `initialize` request to `/mcp`, `Protocol.connect()` threw `"Already connected to a transport"` because the singleton was already bound to the first client's transport.
- Replaced the singleton `getMcpServer()` with a factory function `createMcpServer()`, so each new transport (both `/mcp` StreamableHTTP and `/sse` SSE) gets its own independent MCP Server instance.

### Steps to reproduce (before fix)

```bash
# First request succeeds
curl -X POST "http://127.0.0.1:12306/mcp" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'

# Second request fails with 500: "Already connected to a transport"
curl -X POST "http://127.0.0.1:12306/mcp" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test2","version":"1.0"}}}'
```

### Changes

| File | Change |
|------|--------|
| `app/native-server/src/mcp/mcp-server.ts` | Replace singleton `getMcpServer()` with factory `createMcpServer()` |
| `app/native-server/src/server/index.ts` | Use `createMcpServer()` for each new transport in `/mcp` and `/sse` endpoints |

## Test plan

- [x] First MCP client initialize → succeeds
- [x] Second MCP client initialize (without session ID) → succeeds (previously 500 error)
- [x] Existing session reuse via `mcp-session-id` header → still works
- [x] SSE endpoint `/sse` with multiple clients → works independently