### PR TITLE
fix: create per-session MCP Server instances to support multiple concurrent connections

### DIFF
--- a/app/native-server/src/mcp/mcp-server.ts
+++ b/app/native-server/src/mcp/mcp-server.ts
@@ -1,13 +1,8 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { setupTools } from './register-tools';
 
-export let mcpServer: Server | null = null;
-
-export const getMcpServer = () => {
-  if (mcpServer) {
-    return mcpServer;
-  }
-  mcpServer = new Server(
+export const createMcpServer = () => {
+  const server = new Server(
     {
       name: 'ChromeMcpServer',
       version: '1.0.0',
@@ -19,6 +14,6 @@ export const getMcpServer = () => {
     },
   );
 
-  setupTools(mcpServer);
-  return mcpServer;
+  setupTools(server);
+  return server;
 };

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -22,7 +22,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { getMcpServer } from '../mcp/mcp-server';
+import { createMcpServer } from '../mcp/mcp-server';
 import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
@@ -181,8 +181,8 @@ export class Server {
           this.transportsMap.delete(transport.sessionId);
         });
 
-        const server = getMcpServer();
-        await server.connect(transport);
+        const mcpServer = createMcpServer();
+        await mcpServer.connect(transport);
 
         reply.raw.write(':\n\n');
       } catch (error) {
@@ -235,7 +235,8 @@ export class Server {
             this.transportsMap.delete(transport.sessionId);
           }
         };
-        await getMcpServer().connect(transport);
+        const mcpServer = createMcpServer();
+        await mcpServer.connect(transport);
       } else {
         reply.code(HTTP_STATUS.BAD_REQUEST).send({ error: ERROR_MESSAGES.INVALID_MCP_REQUEST });
         return;


### PR DESCRIPTION
fix: create per-session MCP Server instances to support multiple concurrent connections
The MCP Server (Protocol) instance was a singleton shared across all sessions.
When a second client sent an initialize request, Protocol.connect() threw
"Already connected to a transport" because the singleton was already bound
to the first client's transport.

Replace the singleton getMcpServer() with a factory createMcpServer()
so each new transport gets its own MCP Server instance, allowing
multiple clients to connect simultaneously via both /mcp and /sse endpoints.