### PR TITLE
feat(native-server): implements minimal QwenEngine

### DIFF
--- a/app/chrome-extension/entrypoints/sidepanel/components/AgentChat.vue
+++ b/app/chrome-extension/entrypoints/sidepanel/components/AgentChat.vue
@@ -63,7 +63,7 @@
             :cancelling="chat.cancelling.value"
             :can-cancel="!!chat.currentRequestId.value"
             :can-send="chat.canSend.value"
-            placeholder="Ask Claude to write code..."
+            placeholder="Ask AI to write code..."
             :engine-name="currentEngineName"
             :selected-model="currentSessionModel"
             :available-models="currentAvailableModels"

--- a/app/chrome-extension/entrypoints/sidepanel/components/AgentChat.vue
+++ b/app/chrome-extension/entrypoints/sidepanel/components/AgentChat.vue
@@ -63,7 +63,7 @@
             :cancelling="chat.cancelling.value"
             :can-cancel="!!chat.currentRequestId.value"
             :can-send="chat.canSend.value"
-            placeholder="Ask AI to write code..."
+            placeholder="Ask Claude to write code..."
             :engine-name="currentEngineName"
             :selected-model="currentSessionModel"
             :available-models="currentAvailableModels"

--- a/app/native-server/src/agent/engines/qwen.ts
+++ b/app/native-server/src/agent/engines/qwen.ts
@@ -1,0 +1,236 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { join } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+import type { AgentEngine, EngineExecutionContext, EngineName, EngineInitOptions } from './types';
+import type { RealtimeEvent, AgentMessage } from '../types';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * QwenEngine integrates the Qwen Code CLI as an AgentEngine implementation.
+ *
+ * Uses `qwen -y -p "<instruction>"` for non-interactive agent mode.
+ */
+export class QwenEngine extends EventEmitter implements AgentEngine {
+  readonly name: EngineName = 'qwen';
+  private abortController: AbortController | null = null;
+
+  async initializeAndRun(options: EngineInitOptions, ctx: EngineExecutionContext): Promise<void> {
+    const trimmed = options.instruction.trim();
+    if (!trimmed) {
+      throw new Error('QwenEngine: instruction must not be empty');
+    }
+
+    if (options.signal?.aborted) {
+      throw new Error('QwenEngine: execution was cancelled');
+    }
+
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
+
+    const repoPath = options.projectRoot || process.cwd();
+    const resolvedModel = options.model || '';
+
+    console.error(`[QwenEngine] Starting query with model: ${resolvedModel || 'default'}`);
+    console.error(`[QwenEngine] Working directory: ${repoPath}`);
+
+    // Build command arguments
+    const args: string[] = ['-y']; // YOLO mode - auto-approve all actions
+
+    if (resolvedModel) {
+      args.push('-m', resolvedModel);
+    }
+
+    args.push('-p', trimmed);
+
+    // Ensure project directory exists
+    await mkdir(repoPath, { recursive: true });
+
+    return new Promise<void>((resolve, reject) => {
+      const qwen = spawn('qwen', args, {
+        cwd: repoPath,
+        env: { ...process.env },
+        signal: signal as any,
+      });
+
+      let stdoutBuffer = '';
+      const stderrBuffer: string[] = [];
+      const MAX_STDERR_LINES = 100;
+
+      // Handle stdout - parse for events
+      stdoutBuffer = '';
+      qwen.stdout.on('data', (data: Buffer) => {
+        const text = data.toString();
+        stdoutBuffer += text;
+
+        // Try to parse events from output
+        const lines = text.split('\n');
+        for (const line of lines) {
+          const trimmedLine = line.trim();
+          if (!trimmedLine) continue;
+
+          // Detect tool calls
+          if (trimmedLine.includes('Calling tool') || trimmedLine.includes('Running')) {
+            const toolName = extractToolName(trimmedLine);
+            ctx.emit({
+              type: 'status',
+              data: {
+                sessionId: options.sessionId,
+                status: 'running',
+                message: `Using tool: ${toolName}`,
+                requestId: options.requestId,
+              },
+            });
+          }
+
+          // Detect thinking/processing - emit as assistant message
+          if (trimmedLine.startsWith('Qwen') || trimmedLine.includes('Thinking')) {
+            const message: AgentMessage = {
+              id: randomUUID(),
+              sessionId: options.sessionId,
+              role: 'assistant',
+              content: trimmedLine,
+              messageType: 'chat',
+              createdAt: new Date().toISOString(),
+            };
+            ctx.emit({
+              type: 'message',
+              data: message,
+            });
+          }
+        }
+      });
+
+      // Handle stderr - log and emit as status
+      qwen.stderr.on('data', (data: Buffer) => {
+        const line = data.toString().trim();
+        if (!line) return;
+
+        stderrBuffer.push(line);
+        if (stderrBuffer.length > MAX_STDERR_LINES) {
+          stderrBuffer.splice(0, stderrBuffer.length - MAX_STDERR_LINES);
+        }
+
+        console.error(`[QwenEngine][stderr] ${line}`);
+
+        // Emit as status for visibility
+        ctx.emit({
+          type: 'status',
+          data: {
+            sessionId: options.sessionId,
+            status: 'running',
+            message: line,
+            requestId: options.requestId,
+          },
+        });
+      });
+
+      // Handle process exit
+      qwen.on('close', (code) => {
+        console.error(`[QwenEngine] Process exited with code ${code}`);
+
+        if (code === 0) {
+          // Emit final output as assistant message
+          if (stdoutBuffer.trim()) {
+            const message: AgentMessage = {
+              id: randomUUID(),
+              sessionId: options.sessionId,
+              role: 'assistant',
+              content: stdoutBuffer,
+              messageType: 'chat',
+              isFinal: true,
+              createdAt: new Date().toISOString(),
+            };
+            ctx.emit({
+              type: 'message',
+              data: message,
+            });
+          }
+
+          // Emit completion status
+          ctx.emit({
+            type: 'status',
+            data: {
+              sessionId: options.sessionId,
+              status: 'completed',
+              requestId: options.requestId,
+            },
+          });
+
+          resolve();
+        } else if (code === null || code === 130) {
+          console.error('[QwenEngine] Execution cancelled via abort signal');
+          ctx.emit({
+            type: 'status',
+            data: {
+              sessionId: options.sessionId,
+              status: 'cancelled',
+              requestId: options.requestId,
+            },
+          });
+          reject(new Error('QwenEngine: execution was cancelled'));
+        } else {
+          const stderrOutput = stderrBuffer.join('\n');
+          const errorMessage = `QwenEngine: process terminated with code ${code}\n${stderrOutput}`;
+          ctx.emit({
+            type: 'status',
+            data: {
+              sessionId: options.sessionId,
+              status: 'error',
+              message: errorMessage,
+              requestId: options.requestId,
+            },
+          });
+          reject(new Error(errorMessage));
+        }
+      });
+
+      // Handle process errors
+      qwen.on('error', (err) => {
+        console.error('[QwenEngine] Process error:', err);
+        const errorMessage = `QwenEngine: failed to start - ${err.message}`;
+        ctx.emit({
+          type: 'error',
+          error: errorMessage,
+          data: {
+            sessionId: options.sessionId,
+            requestId: options.requestId,
+          },
+        });
+        reject(new Error(errorMessage));
+      });
+
+      // Handle abort signal
+      signal?.addEventListener('abort', () => {
+        console.error('[QwenEngine] Abort signal received');
+        try {
+          qwen.kill('SIGTERM');
+        } catch (e) {
+          // Ignore if already killed
+        }
+      });
+    });
+  }
+
+  cancel(): void {
+    this.abortController?.abort();
+  }
+}
+
+/**
+ * Extract tool name from log line.
+ */
+function extractToolName(line: string): string {
+  // Try to match "Calling tool: toolName" or similar patterns
+  const match =
+    line.match(/Calling tool[:\s]+([a-zA-Z0-9_-]+)/i) ||
+    line.match(/Running[:\s]+([a-zA-Z0-9_-]+)/i) ||
+    line.match(/Using tool[:\s]+([a-zA-Z0-9_-]+)/i);
+
+  if (match) {
+    return match[1];
+  }
+
+  // Fallback: return first part of line
+  return line.split(' ').slice(0, 3).join(' ') || 'unknown';
+}

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -27,6 +27,7 @@ import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
 import { ClaudeEngine } from '../agent/engines/claude';
+import { QwenEngine } from '../agent/engines/qwen';
 import { closeDb } from '../agent/db';
 import { registerAgentRoutes } from './routes';
 
@@ -55,7 +56,7 @@ export class Server {
     this.fastify = Fastify({ logger: SERVER_CONFIG.LOGGER_ENABLED });
     this.agentStreamManager = new AgentStreamManager();
     this.agentChatService = new AgentChatService({
-      engines: [new CodexEngine(), new ClaudeEngine()],
+      engines: [new CodexEngine(), new ClaudeEngine(), new QwenEngine()],
       streamManager: this.agentStreamManager,
     });
     this.setupPlugins();


### PR DESCRIPTION
This is a basic implementation (working implementation), but with limitations:

What works:

 - ✅ Running qwen -y -p <instruction> via child_process
 - ✅ Parsing output (tool calls, messages)
 - ✅ Sending events to UI (status, message)
 - ✅ Cancellation support (abort signal)
 - ✅ Model selection via -m flag

What is NOT implemented (unlike ClaudeEngine/CodexEngine):

 - ❌ No session support (Qwen CLI doesn't save session IDs)
 - ❌ No MCP integration via settings (only via ~/.qwen/settings.json)
 - ❌ No token/usage statistics parsing
 - ❌ No attachments support (images/files)
 - ❌ No real-time streaming (parsing post-factum)

Status: This is an MVP implementation -- sufficient for testing, but needs further work for production use.

<img width="382" height="964" alt="image" src="https://github.com/user-attachments/assets/490cdf1f-324c-4dc1-865b-02503b6ec7a9" />
