### PR TITLE
fix: exit stdio server when parent process dies (stdin close)

### DIFF
--- a/app/native-server/src/mcp/mcp-server-stdio.ts
+++ b/app/native-server/src/mcp/mcp-server-stdio.ts
@@ -117,6 +117,16 @@ const handleToolCall = async (name: string, args: any): Promise<CallToolResult> 
 async function main() {
   const transport = new StdioServerTransport();
   await getStdioMcpServer().connect(transport);
+
+  // Exit cleanly when the parent process dies (stdin pipe closes).
+  // Without this, the process becomes a zombie after the parent
+  // (e.g. Claude Code) terminates.
+  process.stdin.on('close', () => {
+    process.exit(0);
+  });
+  process.stdin.on('end', () => {
+    process.exit(0);
+  });
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Problem

`mcp-server-stdio.js` processes become zombies when the parent Claude Code session ends. The stdio server has no stdin close detection, so it continues running indefinitely after the parent terminates.

After multiple sessions, 10+ stale processes accumulate and new connections fail with `Invalid MCP request or session` errors.

## Fix

Listen for stdin `close` and `end` events in `main()` to exit cleanly when the parent process dies.

Fixes #300