### PR TITLE
fix: handle stale MCP client reconnection to prevent persistent EOF errors

### DIFF
--- a/app/native-server/src/mcp/mcp-server-stdio.ts
+++ b/app/native-server/src/mcp/mcp-server-stdio.ts
@@ -52,13 +52,24 @@ export const getStdioMcpServer = () => {
   return stdioMcpServer;
 };
 
-export const ensureMcpClient = async () => {
+export const ensureMcpClient = async (forceNew = false) => {
   try {
-    if (mcpClient) {
-      const pingResult = await mcpClient.ping();
-      if (pingResult) {
-        return mcpClient;
+    if (mcpClient && !forceNew) {
+      try {
+        const pingResult = await mcpClient.ping();
+        if (pingResult) {
+          return mcpClient;
+        }
+      } catch {
+        // Ping failed — old client/transport is dead, will rebuild below
+        console.error('[chrome-mcp-stdio] Ping failed, rebuilding client');
       }
+    }
+
+    // Always close the old client before creating a new one
+    if (mcpClient) {
+      try { mcpClient.close(); } catch { /* ignore close errors */ }
+      mcpClient = null;
     }
 
     const config = loadConfig();
@@ -67,9 +78,12 @@ export const ensureMcpClient = async () => {
     await mcpClient.connect(transport);
     return mcpClient;
   } catch (error) {
-    mcpClient?.close();
+    if (mcpClient) {
+      try { mcpClient.close(); } catch { /* ignore close errors */ }
+    }
     mcpClient = null;
-    console.error('Failed to connect to MCP server:', error);
+    console.error('[chrome-mcp-stdio] Failed to connect to MCP server:', error);
+    throw error;
   }
 };
 
@@ -89,29 +103,52 @@ export const setupTools = (server: Server) => {
   server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [] }));
 };
 
+const isConnectionError = (error: any): boolean => {
+  const msg = error?.message || '';
+  return (
+    msg.includes('EOF') ||
+    msg.includes('closed') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('fetch failed') ||
+    msg.includes('client is closing')
+  );
+};
+
 const handleToolCall = async (name: string, args: any): Promise<CallToolResult> => {
-  try {
-    const client = await ensureMcpClient();
-    if (!client) {
-      throw new Error('Failed to connect to MCP server');
+  const DEFAULT_CALL_TIMEOUT_MS = 2 * 60 * 1000;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const client = await ensureMcpClient(attempt > 0);
+      if (!client) {
+        throw new Error('Failed to connect to MCP server');
+      }
+      const result = await client.callTool({ name, arguments: args }, undefined, {
+        timeout: DEFAULT_CALL_TIMEOUT_MS,
+      });
+      return result as CallToolResult;
+    } catch (error: any) {
+      if (attempt === 0 && isConnectionError(error)) {
+        console.error('[chrome-mcp-stdio] Connection error, retrying with fresh client:', error.message);
+        continue;
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error calling tool: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
     }
-    // Use a sane default of 2 minutes; the previous value mistakenly used 2*6*1000 (12s)
-    const DEFAULT_CALL_TIMEOUT_MS = 2 * 60 * 1000;
-    const result = await client.callTool({ name, arguments: args }, undefined, {
-      timeout: DEFAULT_CALL_TIMEOUT_MS,
-    });
-    return result as CallToolResult;
-  } catch (error: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error calling tool: ${error.message}`,
-        },
-      ],
-      isError: true,
-    };
   }
+
+  // Should never reach here, but satisfy TypeScript
+  return {
+    content: [{ type: 'text', text: 'Unexpected error: retry loop exhausted' }],
+    isError: true,
+  };
 };
 
 async function main() {


### PR DESCRIPTION
## Problem

When the HTTP transport to the Chrome extension drops (e.g., browser restart, extension reload, network interruption), the singleton `mcpClient` in `mcp-server-stdio.ts` becomes permanently unusable.

**Root cause:** `ensureMcpClient()` catches `ping()` failures in the outer try-catch, which closes the client and sets it to null — but subsequent calls may still fail because the error is silently swallowed (the function returns `undefined` instead of throwing). Additionally, `handleToolCall()` has no retry logic, so a single transient connection error immediately returns an error to the caller.

This causes persistent `connection closed: EOF` / `client is closing: EOF` errors that can only be resolved by restarting the entire MCP server process.

## Fix

1. **Independent ping error handling** — `ping()` failures are now caught separately and fall through to client rebuild, instead of being caught by the outer try-catch
2. **Explicit old client cleanup** — always `close()` the old client before creating a new one
3. **`forceNew` parameter** — allows callers to explicitly request a fresh client
4. **Automatic retry in `handleToolCall()`** — connection-related errors (EOF, closed, ECONNREFUSED, fetch failed, client is closing) trigger one automatic retry with a freshly built client
5. **Error re-throw** — connection errors are re-thrown instead of silently swallowed

## Testing

Verified with multiple MCP clients (Antigravity, custom Node.js clients) that the patched server correctly recovers from:
- Chrome browser restarts
- Extension reloads
- Network interruptions
- Long idle periods where the HTTP connection times out