### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "mcp-chrome",
+  "version": "0.1.0",
+  "description": "Chrome MCP server for Codex - browser automation via Chrome extension",
+  "author": {
+    "name": "hangwin",
+    "url": "https://github.com/hangwin"
+  },
+  "homepage": "https://github.com/hangwin/mcp-chrome",
+  "repository": "https://github.com/hangwin/mcp-chrome",
+  "keywords": [
+    "mcp",
+    "chrome",
+    "browser",
+    "automation",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "MCP Chrome",
+    "shortDescription": "Control Chrome from Codex via MCP",
+    "longDescription": "Chrome extension-based MCP server that exposes Chrome browser functionality to AI assistants. Enables browser automation, content analysis, and semantic search without launching a separate browser process.",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/hangwin/mcp-chrome"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mcp-chrome": {
+      "command": "npx",
+      "args": [
+        "mcp-chrome-bridge"
+      ]
+    }
+  }
+}

--- a/skills/mcp-chrome/SKILL.md
+++ b/skills/mcp-chrome/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: mcp-chrome
+description: Control Chrome browser from Codex - navigate, interact, and search via MCP.
+---
+
+# MCP Chrome for Codex
+
+Control your Chrome browser through the MCP Chrome extension.
+
+## When to use
+- Automating browser workflows
+- Analyzing web page content
+- Semantic search across browser tabs
+- Testing web UIs without launching a separate browser
+
+## Prerequisites
+- Chrome browser with the MCP Chrome extension installed
+- Node.js with npm/npx
+- See https://github.com/hangwin/mcp-chrome for setup


### PR DESCRIPTION
Adds a `.codex-plugin/plugin.json` manifest so MCP Chrome can be installed as a Codex CLI plugin.

The plugin wraps the existing package via `.mcp.json` using `npx mcp-chrome-bridge`.

**What this adds:**
- `.codex-plugin/plugin.json` — Plugin manifest with metadata
- `.mcp.json` — MCP server reference
- `skills/mcp-chrome/SKILL.md` — Usage guide for Codex

**Related resources:**
- [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) — Curated directory of Codex plugins (open a PR to get listed!)
- [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner) — Security and quality scanner for Codex plugins (scores 0-100, CI action available)