### PR TITLE
fix: replace deprecated unload event with pagehide for Chrome 120+

### DIFF
--- a/app/chrome-extension/entrypoints/element-picker.content.ts
+++ b/app/chrome-extension/entrypoints/element-picker.content.ts
@@ -194,8 +194,8 @@ export default defineContentScript({
     // Register message listener
     chrome.runtime.onMessage.addListener(handleMessage);
 
-    // Cleanup on page unload
-    window.addEventListener('unload', () => {
+    // Cleanup on page unload (using pagehide for Chrome 120+ permissions policy compatibility)
+    window.addEventListener('pagehide', () => {
       chrome.runtime.onMessage.removeListener(handleMessage);
       controller?.dispose();
       controller = null;

--- a/app/chrome-extension/entrypoints/quick-panel.content.ts
+++ b/app/chrome-extension/entrypoints/quick-panel.content.ts
@@ -103,8 +103,8 @@ export default defineContentScript({
     // Register message listener
     chrome.runtime.onMessage.addListener(handleMessage);
 
-    // Cleanup on page unload
-    window.addEventListener('unload', () => {
+    // Cleanup on page unload (using pagehide for Chrome 120+ permissions policy compatibility)
+    window.addEventListener('pagehide', () => {
       chrome.runtime.onMessage.removeListener(handleMessage);
       if (controller) {
         controller.dispose();


### PR DESCRIPTION
## Summary
- Replace deprecated `window.addEventListener('unload', ...)` with `pagehide` in content scripts
- Fixes Chrome 120+ Permissions Policy violation error

## Problem
Chrome 120+ blocks `window.addEventListener('unload')` via Permissions Policy, causing:
```
Permissions policy violation: unload is not allowed in this document
```

## Solution
Use `pagehide` event instead - provides equivalent cleanup functionality while remaining compatible with Chrome's stricter permissions policy.

## Files Changed
- `app/chrome-extension/entrypoints/element-picker.content.ts`
- `app/chrome-extension/entrypoints/quick-panel.content.ts`

## Testing
- Local extension patched and tested  
- Verified no "Permissions policy violation" errors after fix