### PR TITLE
i18n: translate popup home view strings

### DIFF
--- a/app/chrome-extension/_locales/en/messages.json
+++ b/app/chrome-extension/_locales/en/messages.json
@@ -500,5 +500,69 @@
     "message": "Paste JS/CSS/TM here",
     "description": "script textarea placeholder"
   },
-  "placeholderDomainHint": { "message": "example.com", "description": "domain filter placeholder" }
+  "placeholderDomainHint": { "message": "example.com", "description": "domain filter placeholder" },
+
+  "quickToolsLabel": {
+    "message": "Quick Tools",
+    "description": "Section title for the quick tools row in the popup"
+  },
+  "recordingComingSoonTooltip": {
+    "message": "Recording feature in development",
+    "description": "Tooltip on the record/stop record buttons while the feature is not yet shipped"
+  },
+  "enablePageEditTooltip": {
+    "message": "Enable page edit mode",
+    "description": "Tooltip on the web editor toggle button"
+  },
+  "enableElementMarkerTooltip": {
+    "message": "Enable element marker",
+    "description": "Tooltip on the element marker toggle button"
+  },
+  "managementSectionLabel": {
+    "message": "Management",
+    "description": "Section title for the management entries card in the popup"
+  },
+  "agentChatTitle": {
+    "message": "AI Assistant",
+    "description": "Title for the agent chat entry in the popup"
+  },
+  "agentChatDesc": {
+    "message": "AI Agent conversations & tasks",
+    "description": "Description for the agent chat entry in the popup"
+  },
+  "workflowManagementTitle": {
+    "message": "Workflow Management",
+    "description": "Title for the workflow management entry in the popup"
+  },
+  "workflowManagementDesc": {
+    "message": "Record & replay automation flows",
+    "description": "Description for the workflow management entry in the popup"
+  },
+  "elementMarkerTitle": {
+    "message": "Element Marker Management",
+    "description": "Title for the element marker management entry in the popup"
+  },
+  "elementMarkerDesc": {
+    "message": "Manage page element markers",
+    "description": "Description for the element marker management entry in the popup"
+  },
+  "localModelTitle": {
+    "message": "Local Model",
+    "description": "Title for the local model entry in the popup"
+  },
+  "localModelDesc": {
+    "message": "Semantic engine & model management",
+    "description": "Description for the local model entry in the popup"
+  },
+  "comingSoonMessage": {
+    "message": "$FEATURE$ feature is under development, stay tuned",
+    "description": "Toast message shown when a coming-soon feature is invoked",
+    "placeholders": {
+      "feature": { "content": "$1" }
+    }
+  },
+  "featureRecordReplay": {
+    "message": "Recording & Replay",
+    "description": "Display name for the recording & replay feature"
+  }
 }

--- a/app/chrome-extension/_locales/zh_CN/messages.json
+++ b/app/chrome-extension/_locales/zh_CN/messages.json
@@ -488,5 +488,69 @@
     "description": "匹配示例占位符"
   },
   "placeholderScriptHint": { "message": "在此粘贴 JS/CSS/TM", "description": "脚本文本域占位符" },
-  "placeholderDomainHint": { "message": "example.com", "description": "域名筛选占位符" }
+  "placeholderDomainHint": { "message": "example.com", "description": "域名筛选占位符" },
+
+  "quickToolsLabel": {
+    "message": "快捷工具",
+    "description": "弹窗中快捷工具区域的标题"
+  },
+  "recordingComingSoonTooltip": {
+    "message": "录制功能开发中",
+    "description": "录制/停止录制按钮的提示文案（功能尚未上线）"
+  },
+  "enablePageEditTooltip": {
+    "message": "开启页面编辑模式",
+    "description": "网页编辑切换按钮的提示文案"
+  },
+  "enableElementMarkerTooltip": {
+    "message": "开启元素标注",
+    "description": "元素标注切换按钮的提示文案"
+  },
+  "managementSectionLabel": {
+    "message": "管理入口",
+    "description": "弹窗中管理入口区域的标题"
+  },
+  "agentChatTitle": {
+    "message": "智能助手",
+    "description": "弹窗中智能助手入口的标题"
+  },
+  "agentChatDesc": {
+    "message": "AI Agent 对话与任务",
+    "description": "弹窗中智能助手入口的描述"
+  },
+  "workflowManagementTitle": {
+    "message": "工作流管理",
+    "description": "弹窗中工作流管理入口的标题"
+  },
+  "workflowManagementDesc": {
+    "message": "录制与回放自动化流程",
+    "description": "弹窗中工作流管理入口的描述"
+  },
+  "elementMarkerTitle": {
+    "message": "元素标注管理",
+    "description": "弹窗中元素标注管理入口的标题"
+  },
+  "elementMarkerDesc": {
+    "message": "管理页面元素标注",
+    "description": "弹窗中元素标注管理入口的描述"
+  },
+  "localModelTitle": {
+    "message": "本地模型",
+    "description": "弹窗中本地模型入口的标题"
+  },
+  "localModelDesc": {
+    "message": "语义引擎与模型管理",
+    "description": "弹窗中本地模型入口的描述"
+  },
+  "comingSoonMessage": {
+    "message": "$FEATURE$ 功能开发中，敬请期待",
+    "description": "调用尚未上线功能时的 toast 提示",
+    "placeholders": {
+      "feature": { "content": "$1" }
+    }
+  },
+  "featureRecordReplay": {
+    "message": "录制回放",
+    "description": "录制与回放功能的显示名称"
+  }
 }

--- a/app/chrome-extension/entrypoints/popup/App.vue
+++ b/app/chrome-extension/entrypoints/popup/App.vue
@@ -70,33 +70,33 @@
 
         <!-- 快捷工具卡片 -->
         <div class="section">
-          <h2 class="section-title">快捷工具</h2>
+          <h2 class="section-title">{{ getMessage('quickToolsLabel') }}</h2>
           <div class="rr-icon-buttons">
             <button
               class="rr-icon-btn rr-icon-btn-record rr-icon-btn-coming-soon has-tooltip"
               @click="startRecording"
-              data-tooltip="录制功能开发中"
+              :data-tooltip="getMessage('recordingComingSoonTooltip')"
             >
               <RecordIcon :recording="false" />
             </button>
             <button
               class="rr-icon-btn rr-icon-btn-stop rr-icon-btn-coming-soon has-tooltip"
               @click="stopRecording"
-              data-tooltip="录制功能开发中"
+              :data-tooltip="getMessage('recordingComingSoonTooltip')"
             >
               <StopIcon />
             </button>
             <button
               class="rr-icon-btn rr-icon-btn-edit has-tooltip"
               @click="toggleWebEditor"
-              data-tooltip="开启页面编辑模式"
+              :data-tooltip="getMessage('enablePageEditTooltip')"
             >
               <EditIcon />
             </button>
             <button
               class="rr-icon-btn rr-icon-btn-marker has-tooltip"
               @click="toggleElementMarker"
-              data-tooltip="开启元素标注"
+              :data-tooltip="getMessage('enableElementMarkerTooltip')"
             >
               <MarkerIcon />
             </button>
@@ -105,7 +105,7 @@
 
         <!-- 管理入口卡片 -->
         <div class="section">
-          <h2 class="section-title">管理入口</h2>
+          <h2 class="section-title">{{ getMessage('managementSectionLabel') }}</h2>
           <div class="entry-card">
             <button class="entry-item" @click="openAgentSidepanel">
               <div class="entry-icon agent">
@@ -125,8 +125,8 @@
                 </svg>
               </div>
               <div class="entry-content">
-                <span class="entry-title">智能助手</span>
-                <span class="entry-desc">AI Agent 对话与任务</span>
+                <span class="entry-title">{{ getMessage('agentChatTitle') }}</span>
+                <span class="entry-desc">{{ getMessage('agentChatDesc') }}</span>
               </div>
               <svg
                 class="entry-arrow"
@@ -146,10 +146,10 @@
               </div>
               <div class="entry-content">
                 <span class="entry-title">
-                  工作流管理
+                  {{ getMessage('workflowManagementTitle') }}
                   <span class="coming-soon-badge">Coming Soon</span>
                 </span>
-                <span class="entry-desc">录制与回放自动化流程</span>
+                <span class="entry-desc">{{ getMessage('workflowManagementDesc') }}</span>
               </div>
               <svg
                 class="entry-arrow"
@@ -181,8 +181,8 @@
                 </svg>
               </div>
               <div class="entry-content">
-                <span class="entry-title">元素标注管理</span>
-                <span class="entry-desc">管理页面元素标注</span>
+                <span class="entry-title">{{ getMessage('elementMarkerTitle') }}</span>
+                <span class="entry-desc">{{ getMessage('elementMarkerDesc') }}</span>
               </div>
               <svg
                 class="entry-arrow"
@@ -214,8 +214,8 @@
                 </svg>
               </div>
               <div class="entry-content">
-                <span class="entry-title">本地模型</span>
-                <span class="entry-desc">语义引擎与模型管理</span>
+                <span class="entry-title">{{ getMessage('localModelTitle') }}</span>
+                <span class="entry-desc">{{ getMessage('localModelDesc') }}</span>
               </div>
               <svg
                 class="entry-arrow"
@@ -325,7 +325,7 @@
           <circle cx="12" cy="12" r="10" />
           <path d="M12 6v6l4 2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
-        <span>{{ comingSoonToast.feature }} 功能开发中，敬请期待</span>
+        <span>{{ getMessage('comingSoonMessage', [comingSoonToast.feature]) }}</span>
       </div>
     </Transition>
   </div>
@@ -433,7 +433,7 @@ function isFlowBoundToCurrent(flow: any) {
 // 运行记录与覆盖项在侧边栏页面查看
 const startRecording = async () => {
   // TODO: 录制回放功能开发中，暂时拦截
-  showComingSoonToast('录制回放');
+  showComingSoonToast(getMessage('featureRecordReplay'));
   return;
   // if (rrRecording.value) return;
   // try {
@@ -450,7 +450,7 @@ const startRecording = async () => {
 
 const stopRecording = async () => {
   // TODO: 录制回放功能开发中，暂时拦截
-  showComingSoonToast('录制回放');
+  showComingSoonToast(getMessage('featureRecordReplay'));
   return;
   // if (!rrRecording.value) return;
   // try {
@@ -635,7 +635,7 @@ async function openSidepanelAndClose(tab: string) {
 // Open sidepanel from popup for workflow management
 function openWorkflowSidepanel() {
   // TODO: 工作流功能开发中，暂时拦截
-  showComingSoonToast('工作流管理');
+  showComingSoonToast(getMessage('workflowManagementTitle'));
   // openSidepanelAndClose('workflows');
 }
 

--- a/app/chrome-extension/utils/i18n.ts
+++ b/app/chrome-extension/utils/i18n.ts
@@ -225,6 +225,23 @@ const fallbackMessages: Record<string, string> = {
   clearAllCache: 'Clear All Cache',
   expired: 'Expired',
   bookmarksBar: 'Bookmarks Bar',
+
+  // Popup home view
+  quickToolsLabel: 'Quick Tools',
+  recordingComingSoonTooltip: 'Recording feature in development',
+  enablePageEditTooltip: 'Enable page edit mode',
+  enableElementMarkerTooltip: 'Enable element marker',
+  managementSectionLabel: 'Management',
+  agentChatTitle: 'AI Assistant',
+  agentChatDesc: 'AI Agent conversations & tasks',
+  workflowManagementTitle: 'Workflow Management',
+  workflowManagementDesc: 'Record & replay automation flows',
+  elementMarkerTitle: 'Element Marker Management',
+  elementMarkerDesc: 'Manage page element markers',
+  localModelTitle: 'Local Model',
+  localModelDesc: 'Semantic engine & model management',
+  comingSoonMessage: '{0} feature is under development, stay tuned',
+  featureRecordReplay: 'Recording & Replay',
 };
 
 /**


### PR DESCRIPTION
## Summary

The popup home view had inline Chinese strings in `entrypoints/popup/App.vue` (template + a few script callsites), so the popup rendered in Chinese for users whose browser UI locale resolves to anything other than `zh_CN`, even though `_locales/en/messages.json` already exists and most of the same view is already wired through `getMessage()`.

This PR threads the remaining popup strings through the existing i18n pipeline. No new infrastructure — just replaces hardcoded text with `getMessage()` calls and registers the keys.

## Changes

- `entrypoints/popup/App.vue`
  - Section titles: `Quick Tools`, `Management`
  - Quick-tools tooltips (3): record/stop "coming soon", page-edit, element-marker
  - Management entries (4 × title + desc): AI Assistant, Workflow Management, Element Marker Management, Local Model
  - Coming-soon toast: template now uses `comingSoonMessage` with `$FEATURE$` placeholder; the three callers (`startRecording`, `stopRecording`, `openWorkflowSidepanel`) pass localized feature names instead of literal Chinese strings
- `_locales/en/messages.json`, `_locales/zh_CN/messages.json` — 15 new keys (descriptions included)
- `utils/i18n.ts` — corresponding English entries in the `fallbackMessages` map

## Scope

Intentionally limited to `entrypoints/popup/App.vue`. Sibling components (`LocalModelPage.vue`, `ScheduleDialog.vue`, sidepanel, builder, web-editor-v2) still have inline Chinese and can follow in separate PRs to keep this diff reviewable.

## Test plan

- [x] `prettier --check` — clean
- [x] `eslint` — clean
- [x] JSON validation — both messages.json files parse
- [x] `vue-tsc --noEmit` — no new errors introduced (one pre-existing `TS2322` on L287 `@switch-model` exists on `master` and is unrelated)
- [x] Manual verification: load the unpacked extension with browser locale = en, confirm popup home view renders English (Quick Tools / Management / AI Assistant / etc.) and the coming-soon toast substitutes the feature name correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)