### PR TITLE
feat: add Chrome tab group tools (create/update/add_tabs/close/list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ Complete tool list: [Complete Tool List](docs/TOOLS.md)
 </details>
 
 <details>
+<summary><strong>🗂️ Tab Grouping (5 tools)</strong></summary>
+
+- `chrome_tab_group_create` - Create a new tab group from one or more tabs (optional title/color/window)
+- `chrome_tab_group_update` - Rename, recolor, or collapse/expand an existing group
+- `chrome_tab_group_add_tabs` - Add existing tabs to an existing group
+- `chrome_tab_group_close` - Close every tab inside a group
+- `chrome_tab_group_list` - List all tab groups (filter by window/color/title/collapsed) with their tab IDs
+
+Requires Chrome 89+ and the `tabGroups` permission (already declared in the manifest).
+
+</details>
+
+<details>
 <summary><strong>📸 Screenshots & Visual (1 tool)</strong></summary>
 
 - `chrome_screenshot` - Advanced screenshot capture with element targeting, full-page support, and custom dimensions

--- a/README_zh.md
+++ b/README_zh.md
@@ -157,6 +157,19 @@ pnpm list -g mcp-chrome-bridge
 </details>
 
 <details>
+<summary><strong>🗂️ 标签页分组 (5个工具)</strong></summary>
+
+- `chrome_tab_group_create` - 将一个或多个标签页组成新分组（可选标题/颜色/窗口）
+- `chrome_tab_group_update` - 重命名分组、修改颜色或折叠/展开
+- `chrome_tab_group_add_tabs` - 把已有标签页加入到已有分组
+- `chrome_tab_group_close` - 关闭分组中的所有标签页
+- `chrome_tab_group_list` - 列出所有分组（可按窗口/颜色/标题/折叠状态筛选），并附带分组内标签页 ID
+
+需要 Chrome 89+，并已在 manifest 中声明 `tabGroups` 权限。
+
+</details>
+
+<details>
 <summary><strong>📸 截图和视觉 (1个工具)</strong></summary>
 
 - `chrome_screenshot` - 高级截图捕获，支持元素定位、全页面和自定义尺寸

--- a/app/chrome-extension/entrypoints/background/tools/browser/index.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/index.ts
@@ -1,5 +1,12 @@
 export { navigateTool, closeTabsTool, switchTabTool } from './common';
 export { windowTool } from './window';
+export {
+  tabGroupCreateTool,
+  tabGroupUpdateTool,
+  tabGroupAddTabsTool,
+  tabGroupCloseTool,
+  tabGroupListTool,
+} from './tab-group';
 export { vectorSearchTabsContentTool as searchTabsContentTool } from './vector-search';
 export { screenshotTool } from './screenshot';
 export { webFetcherTool, getInteractiveElementsTool } from './web-fetcher';

--- a/app/chrome-extension/entrypoints/background/tools/browser/tab-group.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/tab-group.ts
@@ -1,0 +1,343 @@
+import { createErrorResponse, ToolResult } from '@/common/tool-handler';
+import { BaseBrowserToolExecutor } from '../base-browser';
+import { TOOL_NAMES } from 'chrome-mcp-shared';
+
+type TabGroupColor =
+  | 'grey'
+  | 'blue'
+  | 'red'
+  | 'yellow'
+  | 'green'
+  | 'pink'
+  | 'purple'
+  | 'cyan'
+  | 'orange';
+
+const TAB_GROUP_COLORS: ReadonlyArray<TabGroupColor> = [
+  'grey',
+  'blue',
+  'red',
+  'yellow',
+  'green',
+  'pink',
+  'purple',
+  'cyan',
+  'orange',
+];
+
+const isValidColor = (value: unknown): value is TabGroupColor =>
+  typeof value === 'string' && (TAB_GROUP_COLORS as ReadonlyArray<string>).includes(value);
+
+const requireTabGroupsApi = (): void => {
+  if (typeof chrome === 'undefined' || !chrome.tabGroups || !chrome.tabs?.group) {
+    throw new Error(
+      'chrome.tabGroups / chrome.tabs.group APIs are not available. Ensure the extension has the "tabGroups" permission and is running on Chrome 89+.',
+    );
+  }
+};
+
+const serializeGroup = (group: chrome.tabGroups.TabGroup) => ({
+  groupId: group.id,
+  windowId: group.windowId,
+  title: group.title ?? '',
+  color: group.color,
+  collapsed: group.collapsed,
+});
+
+interface TabGroupCreateParams {
+  tabIds: number[];
+  title?: string;
+  color?: TabGroupColor;
+  windowId?: number;
+}
+
+class TabGroupCreateTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_CREATE;
+
+  async execute(args: TabGroupCreateParams): Promise<ToolResult> {
+    try {
+      requireTabGroupsApi();
+
+      const { tabIds, title, color, windowId } = args || ({} as TabGroupCreateParams);
+      if (!Array.isArray(tabIds) || tabIds.length === 0) {
+        return createErrorResponse('tabIds must be a non-empty array of numeric tab IDs');
+      }
+      if (color !== undefined && !isValidColor(color)) {
+        return createErrorResponse(
+          `Invalid color "${color}". Must be one of: ${TAB_GROUP_COLORS.join(', ')}`,
+        );
+      }
+
+      const createOptions: chrome.tabs.GroupOptions = { tabIds };
+      if (typeof windowId === 'number') {
+        createOptions.createProperties = { windowId };
+      }
+
+      const groupId = await chrome.tabs.group(createOptions);
+
+      const updateProps: chrome.tabGroups.UpdateProperties = {};
+      if (typeof title === 'string') updateProps.title = title;
+      if (color !== undefined) updateProps.color = color;
+      const updatedGroup =
+        Object.keys(updateProps).length > 0
+          ? await chrome.tabGroups.update(groupId, updateProps)
+          : await chrome.tabGroups.get(groupId);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Created tab group ${groupId} with ${tabIds.length} tab(s)`,
+              ...serializeGroup(updatedGroup),
+              tabIds,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      console.error('Error in TabGroupCreateTool.execute:', error);
+      return createErrorResponse(
+        `Error creating tab group: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+export const tabGroupCreateTool = new TabGroupCreateTool();
+
+interface TabGroupUpdateParams {
+  groupId: number;
+  title?: string;
+  color?: TabGroupColor;
+  collapsed?: boolean;
+}
+
+class TabGroupUpdateTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_UPDATE;
+
+  async execute(args: TabGroupUpdateParams): Promise<ToolResult> {
+    try {
+      requireTabGroupsApi();
+
+      const { groupId, title, color, collapsed } = args || ({} as TabGroupUpdateParams);
+      if (typeof groupId !== 'number') {
+        return createErrorResponse('groupId is required and must be a number');
+      }
+      if (color !== undefined && !isValidColor(color)) {
+        return createErrorResponse(
+          `Invalid color "${color}". Must be one of: ${TAB_GROUP_COLORS.join(', ')}`,
+        );
+      }
+
+      const updateProps: chrome.tabGroups.UpdateProperties = {};
+      if (typeof title === 'string') updateProps.title = title;
+      if (color !== undefined) updateProps.color = color;
+      if (typeof collapsed === 'boolean') updateProps.collapsed = collapsed;
+
+      if (Object.keys(updateProps).length === 0) {
+        return createErrorResponse('At least one of title, color, or collapsed must be provided');
+      }
+
+      const updatedGroup = await chrome.tabGroups.update(groupId, updateProps);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Updated tab group ${groupId}`,
+              ...serializeGroup(updatedGroup),
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      console.error('Error in TabGroupUpdateTool.execute:', error);
+      return createErrorResponse(
+        `Error updating tab group: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+export const tabGroupUpdateTool = new TabGroupUpdateTool();
+
+interface TabGroupAddTabsParams {
+  groupId: number;
+  tabIds: number[];
+}
+
+class TabGroupAddTabsTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_ADD_TABS;
+
+  async execute(args: TabGroupAddTabsParams): Promise<ToolResult> {
+    try {
+      requireTabGroupsApi();
+
+      const { groupId, tabIds } = args || ({} as TabGroupAddTabsParams);
+      if (typeof groupId !== 'number') {
+        return createErrorResponse('groupId is required and must be a number');
+      }
+      if (!Array.isArray(tabIds) || tabIds.length === 0) {
+        return createErrorResponse('tabIds must be a non-empty array of numeric tab IDs');
+      }
+
+      const returnedGroupId = await chrome.tabs.group({ groupId, tabIds });
+      const group = await chrome.tabGroups.get(returnedGroupId);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Added ${tabIds.length} tab(s) to group ${returnedGroupId}`,
+              ...serializeGroup(group),
+              addedTabIds: tabIds,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      console.error('Error in TabGroupAddTabsTool.execute:', error);
+      return createErrorResponse(
+        `Error adding tabs to group: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+export const tabGroupAddTabsTool = new TabGroupAddTabsTool();
+
+interface TabGroupCloseParams {
+  groupId: number;
+}
+
+class TabGroupCloseTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_CLOSE;
+
+  async execute(args: TabGroupCloseParams): Promise<ToolResult> {
+    try {
+      requireTabGroupsApi();
+
+      const { groupId } = args || ({} as TabGroupCloseParams);
+      if (typeof groupId !== 'number') {
+        return createErrorResponse('groupId is required and must be a number');
+      }
+
+      const tabs = await chrome.tabs.query({ groupId });
+      const tabIds = tabs.map((tab) => tab.id).filter((id): id is number => typeof id === 'number');
+
+      if (tabIds.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: false,
+                message: `No tabs found in group ${groupId}`,
+                groupId,
+                closedCount: 0,
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+
+      await chrome.tabs.remove(tabIds);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Closed ${tabIds.length} tab(s) in group ${groupId}`,
+              groupId,
+              closedCount: tabIds.length,
+              closedTabIds: tabIds,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      console.error('Error in TabGroupCloseTool.execute:', error);
+      return createErrorResponse(
+        `Error closing tab group: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+export const tabGroupCloseTool = new TabGroupCloseTool();
+
+interface TabGroupListParams {
+  windowId?: number;
+  color?: TabGroupColor;
+  title?: string;
+  collapsed?: boolean;
+}
+
+class TabGroupListTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_LIST;
+
+  async execute(args: TabGroupListParams): Promise<ToolResult> {
+    try {
+      requireTabGroupsApi();
+
+      const { windowId, color, title, collapsed } = args || ({} as TabGroupListParams);
+      if (color !== undefined && !isValidColor(color)) {
+        return createErrorResponse(
+          `Invalid color "${color}". Must be one of: ${TAB_GROUP_COLORS.join(', ')}`,
+        );
+      }
+
+      const queryInfo: chrome.tabGroups.QueryInfo = {};
+      if (typeof windowId === 'number') queryInfo.windowId = windowId;
+      if (color !== undefined) queryInfo.color = color;
+      if (typeof title === 'string') queryInfo.title = title;
+      if (typeof collapsed === 'boolean') queryInfo.collapsed = collapsed;
+
+      const groups = await chrome.tabGroups.query(queryInfo);
+
+      const enriched = await Promise.all(
+        groups.map(async (group) => {
+          const tabs = await chrome.tabs.query({ groupId: group.id });
+          return {
+            ...serializeGroup(group),
+            tabIds: tabs.map((tab) => tab.id).filter((id): id is number => typeof id === 'number'),
+          };
+        }),
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              groupCount: enriched.length,
+              groups: enriched,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      console.error('Error in TabGroupListTool.execute:', error);
+      return createErrorResponse(
+        `Error listing tab groups: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+export const tabGroupListTool = new TabGroupListTool();

--- a/app/chrome-extension/wxt.config.ts
+++ b/app/chrome-extension/wxt.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
       'alarms',
       // Allow programmatic control of Chrome Side Panel
       'sidePanel',
+      // Allow grouping/labeling tabs via the tab-group MCP tools
+      'tabGroups',
     ],
     host_permissions: ['<all_urls>'],
     options_ui: {

--- a/packages/shared/src/tools.ts
+++ b/packages/shared/src/tools.ts
@@ -39,6 +39,11 @@ export const TOOL_NAMES = {
     PERFORMANCE_STOP_TRACE: 'performance_stop_trace',
     PERFORMANCE_ANALYZE_INSIGHT: 'performance_analyze_insight',
     GIF_RECORDER: 'chrome_gif_recorder',
+    TAB_GROUP_CREATE: 'chrome_tab_group_create',
+    TAB_GROUP_UPDATE: 'chrome_tab_group_update',
+    TAB_GROUP_ADD_TABS: 'chrome_tab_group_add_tabs',
+    TAB_GROUP_CLOSE: 'chrome_tab_group_close',
+    TAB_GROUP_LIST: 'chrome_tab_group_list',
   },
   RECORD_REPLAY: {
     FLOW_RUN: 'record_replay_flow_run',
@@ -1395,6 +1400,131 @@ export const TOOL_SCHEMAS: Tool[] = [
         },
       },
       required: ['action'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_CREATE,
+    description:
+      'Create a new Chrome tab group from a list of tabs. Optionally set the group title, color, or target window. Returns the new groupId. Requires Chrome 89+ and the "tabGroups" permission.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabIds: {
+          type: 'array',
+          items: { type: 'number' },
+          minItems: 1,
+          description:
+            'Tab IDs to include in the new group. All tabs must belong to the same window (Chrome moves them together when grouping).',
+        },
+        title: {
+          type: 'string',
+          description: 'Optional title displayed on the group label.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'Optional color for the group label. Defaults to a Chrome-assigned color.',
+        },
+        windowId: {
+          type: 'number',
+          description:
+            'Optional window ID for the new group. Tabs must already live in this window; otherwise Chrome ignores this hint.',
+        },
+      },
+      required: ['tabIds'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_UPDATE,
+    description:
+      'Update an existing Chrome tab group: rename it, change its color, or expand/collapse it. At least one of title, color, or collapsed must be provided.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the group to update (from chrome_tab_group_create or _list).',
+        },
+        title: {
+          type: 'string',
+          description: 'New title for the group label. Pass an empty string to clear the title.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'New color for the group label.',
+        },
+        collapsed: {
+          type: 'boolean',
+          description:
+            'Collapse (true) or expand (false) the group. Note: Chrome cannot collapse a group whose tab is currently active.',
+        },
+      },
+      required: ['groupId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_ADD_TABS,
+    description:
+      'Add one or more existing tabs to an existing Chrome tab group. Tabs must be in the same window as the group; otherwise Chrome rejects the call.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the existing group to add tabs to.',
+        },
+        tabIds: {
+          type: 'array',
+          items: { type: 'number' },
+          minItems: 1,
+          description: 'Tab IDs to add to the group.',
+        },
+      },
+      required: ['groupId', 'tabIds'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_CLOSE,
+    description:
+      'Close all tabs that belong to a Chrome tab group. The group itself disappears once empty. Use chrome_tab_group_update with collapsed=true if you only want to hide the group.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the group whose tabs should be closed.',
+        },
+      },
+      required: ['groupId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_LIST,
+    description:
+      'List all Chrome tab groups, optionally filtered by window, color, title, or collapsed state. Each entry includes the tab IDs that currently belong to the group.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        windowId: {
+          type: 'number',
+          description: 'Restrict results to groups in a specific window.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'Restrict results to groups with this color.',
+        },
+        title: {
+          type: 'string',
+          description: 'Restrict results to groups with this exact title.',
+        },
+        collapsed: {
+          type: 'boolean',
+          description: 'Restrict results to collapsed (true) or expanded (false) groups.',
+        },
+      },
+      required: [],
     },
   },
 ];


### PR DESCRIPTION
## Summary

Adds five tools that wrap the Chrome `tabs.group` / `tabGroups` APIs so MCP clients can organize their automation tabs into named, collapsed groups instead of leaving loose tabs in the user's daily window.

## Tools added

| Tool | Args | Purpose |
|---|---|---|
| `chrome_tab_group_create` | `tabIds`, `title?`, `color?`, `windowId?` | Create a new group from existing tabs. Returns `groupId`. |
| `chrome_tab_group_update` | `groupId`, `title?`, `color?`, `collapsed?` | Rename / recolor / collapse / expand a group. |
| `chrome_tab_group_add_tabs` | `groupId`, `tabIds` | Add more tabs to an existing group. |
| `chrome_tab_group_close` | `groupId` | Close all tabs in a group (group disappears when empty). |
| `chrome_tab_group_list` | `windowId?`, `color?`, `title?`, `collapsed?` | Enumerate groups (returns enriched entries with `tabIds`). |

A new `tabGroups` permission has been added to the extension manifest.

## Why this matters

Without these, an MCP client running multi-tab research (price comparison, multi-source lookup, etc.) leaves a pile of tabs in the user's main window, and the user has to close them one by one. With grouping, the client can:

1. Open N tabs with \`background: true\`.
2. \`chrome_tab_group_create\` → \`chrome_tab_group_update { collapsed: true }\` → only the group label shows in the tab bar.
3. Extract data in parallel from each tab.
4. \`chrome_tab_group_close\` → all tabs gone in one call.

End-user impact: their daily window stays clean during automation, and they can collapse/expand the group on their own to review what the agent is doing.

## Verification

- \`pnpm build:shared\`, \`pnpm build:extension\`, \`pnpm build:native\` all pass.
- Built extension manifest confirmed to include \`tabGroups\` permission and the five new tool names.
- Live test on macOS Chrome: opened 5 search-result tabs in \`background: true\`, called \`chrome_tab_group_create\` (got groupId), called \`chrome_tab_group_update { collapsed: true }\` (group collapsed in the tab bar without disturbing the active tab), called \`chrome_javascript\` against each grouped tab to extract data in parallel — all worked. The "active tab cannot be collapsed" Chrome quirk is documented in the schema.

## Notes

- The "active tab cannot be collapsed" restriction is a Chrome behavior, not an MCP one. The collapse pattern works as long as the tabs were opened with \`background: true\` (which is the recommended pattern for automation tabs anyway).
- \`chrome_tab_group_list\` returns enriched entries (group metadata + tabIds in that group) so callers don't need a separate \`chrome.tabs.query\` round-trip.
- The new permission requires the user to accept a prompt on extension reload.