### PR TITLE
fix(native-server): use per-session MCP Server factory (closes #345)

### DIFF
--- a/app/native-server/src/mcp/mcp-server.test.ts
+++ b/app/native-server/src/mcp/mcp-server.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, jest } from '@jest/globals';
+
+// Mock the native messaging host singleton so importing mcp-server (which
+// transitively imports the host via register-tools) doesn't attach to stdin
+// or block on extension responses during tests.
+jest.mock('../native-messaging-host', () => ({
+  __esModule: true,
+  default: {
+    sendRequestToExtensionAndWait: () => Promise.resolve({ status: 'success', items: [] }),
+    sendMessage: () => {},
+  },
+}));
+
+import { createMcpServer } from './mcp-server';
+
+describe('createMcpServer (multi-session support — regression for hangwin/mcp-chrome#345)', () => {
+  test('returns a fresh Server instance per call (not memoized)', () => {
+    const a = createMcpServer();
+    const b = createMcpServer();
+    expect(a).not.toBe(b);
+  });
+
+  test('two instances each route requests to their own transport (no shared _transport)', async () => {
+    const serverA = createMcpServer();
+    const serverB = createMcpServer();
+
+    const makeMockTransport = () => {
+      const mock: any = {
+        start: jest.fn(async () => {}),
+        close: jest.fn(async () => {}),
+        send: jest.fn(async () => {}),
+        onmessage: undefined as ((msg: unknown) => void) | undefined,
+        onclose: undefined as (() => void) | undefined,
+        onerror: undefined as ((err: Error) => void) | undefined,
+      };
+      return mock;
+    };
+
+    const transportA = makeMockTransport();
+    const transportB = makeMockTransport();
+
+    await serverA.connect(transportA as any);
+    await serverB.connect(transportB as any);
+
+    expect(transportA.start).toHaveBeenCalledTimes(1);
+    expect(transportB.start).toHaveBeenCalledTimes(1);
+
+    // Simulate an inbound tools/list request on transport A.
+    // Under the pre-fix singleton, both servers shared one underlying
+    // `_transport` (the last one connected — transportB), so the response
+    // would go to transportB.send rather than transportA.send.
+    transportA.onmessage?.({
+      jsonrpc: '2.0',
+      id: 'req-1',
+      method: 'tools/list',
+      params: {},
+    });
+
+    // Let the async handler resolve.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(transportA.send).toHaveBeenCalled();
+    expect(transportB.send).not.toHaveBeenCalled();
+  });
+});

--- a/app/native-server/src/mcp/mcp-server.ts
+++ b/app/native-server/src/mcp/mcp-server.ts
@@ -1,13 +1,16 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { setupTools } from './register-tools';
 
-export let mcpServer: Server | null = null;
-
-export const getMcpServer = () => {
-  if (mcpServer) {
-    return mcpServer;
-  }
-  mcpServer = new Server(
+/**
+ * Create a new MCP Server instance with tools registered.
+ *
+ * Must be called per MCP session, not memoized. The
+ * @modelcontextprotocol/sdk `Server.connect(transport)` call assigns
+ * `this._transport = transport`, so a singleton shared across sessions
+ * orphans earlier transports when a new client initializes. See #345.
+ */
+export const createMcpServer = () => {
+  const server = new Server(
     {
       name: 'ChromeMcpServer',
       version: '1.0.0',
@@ -19,6 +22,6 @@ export const getMcpServer = () => {
     },
   );
 
-  setupTools(mcpServer);
-  return mcpServer;
+  setupTools(server);
+  return server;
 };

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -22,7 +22,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { getMcpServer } from '../mcp/mcp-server';
+import { createMcpServer } from '../mcp/mcp-server';
 import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
@@ -181,7 +181,7 @@ export class Server {
           this.transportsMap.delete(transport.sessionId);
         });
 
-        const server = getMcpServer();
+        const server = createMcpServer();
         await server.connect(transport);
 
         reply.raw.write(':\n\n');
@@ -235,7 +235,7 @@ export class Server {
             this.transportsMap.delete(transport.sessionId);
           }
         };
-        await getMcpServer().connect(transport);
+        await createMcpServer().connect(transport);
       } else {
         reply.code(HTTP_STATUS.BAD_REQUEST).send({ error: ERROR_MESSAGES.INVALID_MCP_REQUEST });
         return;


### PR DESCRIPTION
Closes #345

## Problem

The HTTP server's `transportsMap` already routes requests per session ID, but every new MCP `initialize` calls `getMcpServer().connect(transport)` on a singleton MCP server. `@modelcontextprotocol/sdk`'s `Server.connect()` reassigns `this._transport`, so the second client's init silently orphans the first: subsequent requests on session 1's transport reach the server, but responses are written via session 2's transport.

End-user symptom: a second MCP client attaching to the bridge breaks the first one. Recovery requires manual Disconnect/Connect on the extension popup plus reconnecting each client for every context switch.

## Fix

Convert `getMcpServer()` (singleton) → `createMcpServer()` (factory). Each new MCP session gets its own Server instance bound to its own transport.

- `setupTools` is per-instance pure (registers handlers on the passed Server)
- The extension-side native messaging pipe already routes by `requestId` UUIDs (`pendingRequests` Map in `native-messaging-host.ts`), so concurrency at the per-tab boundary is unchanged
- `chrome.runtime.connectNative` 1-port-per-extension and `chrome.debugger` per-tab attachment remain as Chrome rules (out of scope · natural per-tab isolation works for typical workflows where each client drives different tabs)

## Diff

3 files, +80 / -12:

- `app/native-server/src/mcp/mcp-server.ts` — singleton → factory (+ short doc comment explaining the SDK transport-replacement rule)
- `app/native-server/src/server/index.ts` — 3 call sites updated (import + SSE branch + POST /mcp init branch)
- `app/native-server/src/mcp/mcp-server.test.ts` — new test file

## Tests

`pnpm jest src/mcp/mcp-server.test.ts --coverage=false` — both pass:

1. **Identity** — `createMcpServer()` returns distinct Server instances per call (locks in the factory pattern · regression guard against future singleton-back refactor)
2. **Behavior** — two instances each connected to mock transports: a request inbound on transport A produces a response via transport A's `send`, NOT transport B's. This assertion would FAIL under the pre-fix singleton because both servers shared `_transport = transportB`.

## Note on existing test failure

`src/server/server.test.ts` (existing test) fails on this branch with `Cannot find module '../constant/index.js' from 'src/agent/tool-bridge.ts'`. I verified this is **pre-existing on `master`** (same error after `git stash`-ing the patch and checking out the file from master). Not caused by this PR.

## Manual end-to-end verification

Not done in this PR. The unit tests above prove the SDK transport-replacement bug is fixed at the factory boundary, but I did not install the patched bridge globally to verify two real MCP clients can run concurrently end-to-end. Happy to add that or any further integration tests if helpful.