### PR TITLE
feat(network_request): add tabId/tabUrl/windowId targeting

### DIFF
--- a/app/chrome-extension/entrypoints/background/tools/browser/network-request.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/network-request.ts
@@ -4,9 +4,10 @@ import { TOOL_NAMES } from 'chrome-mcp-shared';
 import { TOOL_MESSAGE_TYPES } from '@/common/message-types';
 
 const DEFAULT_NETWORK_REQUEST_TIMEOUT = 30000; // For sending a single request via content script
+const NEW_TAB_LOAD_DELAY_MS = 3000; // Mirrors inject-script / web-fetcher — gives a newly created tab time to hydrate before we run fetch in it.
 
 interface NetworkRequestToolParams {
-  url: string; // URL is always required
+  url: string; // Request URL (required)
   method?: string; // Defaults to GET
   headers?: Record<string, string>; // User-provided headers
   body?: any; // User-provided body
@@ -15,10 +16,31 @@ interface NetworkRequestToolParams {
   // Shape: { fields?: Record<string, string|number|boolean>, files?: Array<{ name: string, fileUrl?: string, filePath?: string, base64Data?: string, filename?: string, contentType?: string }> }
   // Or a compact array: [ [name, fileSpec, filename?], ... ] where fileSpec can be 'url:...', 'file:/abs/path', 'base64:...'
   formData?: any;
+  // ─── Tab targeting (added 2026-05) ──────────────────────────────────────
+  // Without these the tool fires from the currently active tab, which
+  // breaks credentialed cross-origin fetches (the active tab's origin
+  // owns the cookies the fetch sees). Pass one of these to make the
+  // request fire from a tab at the origin you actually want.
+  tabId?: number; // Direct tab id (most precise).
+  tabUrl?: string; // Find a tab whose URL matches, or open a new one. Named
+  //                 tabUrl rather than url because url is already the
+  //                 request URL.
+  windowId?: number; // When picking active tab, restrict to this window.
+  background?: boolean; // When true (default for this tool — see comment
+  //                       in execute), do NOT activate the target tab.
+  //                       This diverges from inject-script (which defaults
+  //                       to false) because a network call should never
+  //                       yank the user out of whatever tab they're
+  //                       reading.
 }
 
 /**
  * NetworkRequestTool - Sends network requests based on provided parameters.
+ *
+ * By default the request fires from the currently active tab. To target a
+ * specific origin's tab (e.g. for credentialed cross-origin fetches where
+ * the request URL's domain must match the tab's origin), pass `tabId`,
+ * `tabUrl`, or `windowId`.
  */
 class NetworkRequestTool extends BaseBrowserToolExecutor {
   name = TOOL_NAMES.BROWSER.NETWORK_REQUEST;
@@ -30,6 +52,14 @@ class NetworkRequestTool extends BaseBrowserToolExecutor {
       headers = {},
       body,
       timeout = DEFAULT_NETWORK_REQUEST_TIMEOUT,
+      tabId,
+      tabUrl,
+      windowId,
+      // Tools that pick a non-active tab should not steal focus on each
+      // call. The active-tab fallback (no targeting args) preserves
+      // existing behavior — `background` is only consulted when we
+      // actually picked a non-active tab.
+      background = true,
     } = args;
 
     console.log(`NetworkRequestTool: Executing with options:`, args);
@@ -39,20 +69,19 @@ class NetworkRequestTool extends BaseBrowserToolExecutor {
     }
 
     try {
-      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (!tabs[0]?.id) {
-        return createErrorResponse('No active tab found or tab has no ID.');
+      const targetTabId = await resolveTargetTab({ tabId, tabUrl, windowId, background });
+      if (typeof targetTabId !== 'number') {
+        return createErrorResponse(targetTabId.error);
       }
-      const activeTabId = tabs[0].id;
 
       // Ensure content script is available in the target tab
-      await this.injectContentScript(activeTabId, ['inject-scripts/network-helper.js']);
+      await this.injectContentScript(targetTabId, ['inject-scripts/network-helper.js']);
 
       console.log(
-        `NetworkRequestTool: Sending to content script: URL=${url}, Method=${method}, Headers=${Object.keys(headers).join(',')}, BodyType=${typeof body}`,
+        `NetworkRequestTool: Sending to content script (tab ${targetTabId}): URL=${url}, Method=${method}, Headers=${Object.keys(headers).join(',')}, BodyType=${typeof body}`,
       );
 
-      const resultFromContentScript = await this.sendMessageToTab(activeTabId, {
+      const resultFromContentScript = await this.sendMessageToTab(targetTabId, {
         action: TOOL_MESSAGE_TYPES.NETWORK_SEND_REQUEST,
         url: url,
         method: method,
@@ -80,6 +109,73 @@ class NetworkRequestTool extends BaseBrowserToolExecutor {
       );
     }
   }
+}
+
+/**
+ * Pick a tab to run the network request in, mirroring the tab-resolution
+ * pattern used by inject-script and web-fetcher:
+ *
+ *   1. If `tabId` is supplied, use it directly.
+ *   2. Else if `tabUrl` is supplied, find a matching tab; create one if none.
+ *   3. Else fall back to the active tab (optionally restricted to a window).
+ *
+ * Returns a tab id on success, or `{ error: string }` on a known failure.
+ * Throws on unexpected chrome.* errors (caller wraps in createErrorResponse).
+ */
+async function resolveTargetTab(opts: {
+  tabId?: number;
+  tabUrl?: string;
+  windowId?: number;
+  background: boolean;
+}): Promise<number | { error: string }> {
+  const { tabId, tabUrl, windowId, background } = opts;
+
+  if (typeof tabId === 'number') {
+    // Validate the tab still exists; chrome.tabs.get throws if not.
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      return tab.id ?? { error: `Tab ${tabId} has no ID` };
+    } catch {
+      return { error: `Tab ${tabId} does not exist` };
+    }
+  }
+
+  if (typeof tabUrl === 'string' && tabUrl.length > 0) {
+    // Normalize trailing slashes for the match.
+    const target = tabUrl.endsWith('/') ? tabUrl.slice(0, -1) : tabUrl;
+    const allTabs = await chrome.tabs.query({});
+    const match = allTabs.find((t) => {
+      const u = t.url?.endsWith('/') ? t.url.slice(0, -1) : t.url;
+      return u === target;
+    });
+    if (match?.id) {
+      console.log(`NetworkRequestTool: matched existing tab ${match.id} for url ${tabUrl}`);
+      return match.id;
+    }
+    // No match — open a new tab. Use `active: !background` so callers
+    // who opt out of background get focus.
+    console.log(`NetworkRequestTool: no tab found for url ${tabUrl}, creating one`);
+    const created = await chrome.tabs.create({
+      url: tabUrl,
+      active: background === true ? false : true,
+      windowId,
+    });
+    // Give the page time to hydrate before we inject the network-helper.
+    await new Promise((resolve) => setTimeout(resolve, NEW_TAB_LOAD_DELAY_MS));
+    return created.id ?? { error: 'Failed to create tab' };
+  }
+
+  // Active-tab fallback. Preserves the pre-2026-05 behavior — no focus
+  // change, no tab creation — for callers that don't pass any targeting
+  // args.
+  const tabs =
+    typeof windowId === 'number'
+      ? await chrome.tabs.query({ active: true, windowId })
+      : await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tabs[0]?.id) {
+    return { error: 'No active tab found or tab has no ID.' };
+  }
+  return tabs[0].id;
 }
 
 export const networkRequestTool = new NetworkRequestTool();

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -227,7 +227,9 @@ Stop debugger capture and return data with response bodies.
 
 ### `chrome_network_request`
 
-Send custom HTTP requests.
+Send custom HTTP requests with the cookies, TLS fingerprint, and other context of a chosen tab.
+
+By default the request runs in the currently active tab. For credentialed cross-origin fetches — where the request URL's domain must match the tab's origin to get the right cookies — pass `tabId` or `tabUrl` to pick a tab at the origin you actually want.
 
 **Parameters**:
 
@@ -235,8 +237,14 @@ Send custom HTTP requests.
 - `method` (string, optional): HTTP method (default: "GET")
 - `headers` (object, optional): Request headers
 - `body` (string, optional): Request body
+- `timeout` (number, optional): Timeout in milliseconds (default: 30000)
+- `formData` (object, optional): Multipart/form-data descriptor (see schema for details)
+- `tabId` (number, optional): Target an existing tab by ID. Most precise way to pick the origin the request fires from. Overrides `tabUrl` / active-tab selection.
+- `tabUrl` (string, optional): Find a tab whose URL matches this value, or create one if none exists. Named `tabUrl` (not `url`) because `url` is already the request URL.
+- `windowId` (number, optional): When the active-tab fallback is used (no `tabId` / `tabUrl` supplied), restrict the active-tab query to this window.
+- `background` (boolean, optional, default true): When true, do not activate the chosen tab — a network call should not yank the user out of whatever tab they are reading. Only consulted when `tabId` / `tabUrl` / `windowId` is supplied. Set false to focus the tab anyway.
 
-**Example**:
+**Example (default — active tab)**:
 
 ```json
 {
@@ -246,6 +254,29 @@ Send custom HTTP requests.
     "Content-Type": "application/json"
   },
   "body": "{\"key\": \"value\"}"
+}
+```
+
+**Example (credentialed cross-origin — pick a tab by URL)**:
+
+```json
+{
+  "url": "https://www.example.com/dapi/some-endpoint",
+  "method": "POST",
+  "headers": { "Content-Type": "application/json" },
+  "body": "{\"action\":\"foo\"}",
+  "tabUrl": "https://www.example.com/"
+}
+```
+
+The first call opens example.com in a background tab (if none is open already), then fires the POST from that tab so example.com's cookies are included. Subsequent calls reuse the matched tab.
+
+**Example (pin to a known tab id)**:
+
+```json
+{
+  "url": "https://api.example.com/inventory",
+  "tabId": 42
 }
 ```
 

--- a/packages/shared/src/tools.ts
+++ b/packages/shared/src/tools.ts
@@ -563,7 +563,8 @@ export const TOOL_SCHEMAS: Tool[] = [
   },
   {
     name: TOOL_NAMES.BROWSER.NETWORK_REQUEST,
-    description: 'Send a network request from the browser with cookies and other browser context',
+    description:
+      "Send a network request from the browser with the cookies, TLS fingerprint, and other context of a chosen tab. By default the request runs in the currently active tab; pass tabId or tabUrl to run it from a tab at a specific origin (required for credentialed cross-origin fetches, where the request URL's domain must match the tab's origin).",
     inputSchema: {
       type: 'object',
       properties: {
@@ -591,6 +592,26 @@ export const TOOL_SCHEMAS: Tool[] = [
           type: 'object',
           description:
             'Multipart/form-data descriptor. If provided, overrides body and builds FormData with optional file attachments. Shape: { fields?: Record<string,string|number|boolean>, files?: Array<{ name: string, fileUrl?: string, filePath?: string, base64Data?: string, filename?: string, contentType?: string }> }. Also supports a compact array form: [ [name, fileSpec, filename?], ... ] where fileSpec may be url:, file:, or base64:.',
+        },
+        tabId: {
+          type: 'number',
+          description:
+            'Target an existing tab by ID. Most precise way to pick the origin the request fires from. Overrides tabUrl/active-tab selection when provided.',
+        },
+        tabUrl: {
+          type: 'string',
+          description:
+            'Find a tab whose URL matches this value, or create one if none exists. Use when you know the origin you need to fetch from but not which tab is open (e.g. "https://www.example.com/"). Named tabUrl, not url, because url is already the request URL.',
+        },
+        windowId: {
+          type: 'number',
+          description:
+            'When the active-tab fallback is used (no tabId/tabUrl supplied), restrict the active-tab query to this window.',
+        },
+        background: {
+          type: 'boolean',
+          description:
+            'When true (default), do not activate the chosen tab — a network call should not yank the user out of whatever tab they are reading. Only consulted when tabId/tabUrl/windowId is supplied (the active-tab fallback never changes focus). Set false to focus the tab anyway.',
         },
       },
       required: ['url'],


### PR DESCRIPTION
## Motivation

`chrome_network_request` currently hardcodes the active tab as the fetch's execution context:

```typescript
const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
if (!tabs[0]?.id) {
  return createErrorResponse('No active tab found or tab has no ID.');
}
const activeTabId = tabs[0].id;
```

That breaks the most useful case for a fetch-relay tool — **credentialed cross-origin fetches**. The cookies and TLS context of a `fetch()` are determined by the tab it fires from. So a fetch to `example.com` from a tab open on `gmail.com` fails: example.com's session cookies aren't included, and the cross-origin preflight rejects the request.

For agents that want to make authenticated API calls to a specific service (one whose tab the user already has open and signed in), there's currently no way to pin the network call to that tab. The agent would have to `chrome_switch_tab` first — yanking the user out of whatever they're doing — and even then, the agent has to discover which tab is the right one.

## What this PR does

Adds the same tab-resolution pattern that `chrome_inject_script` and `chrome_web_fetcher` already use to `chrome_network_request`:

- **`tabId`** (number, optional) — direct target by tab id. Most precise way to pick the origin the request fires from.
- **`tabUrl`** (string, optional) — find a tab whose URL matches, or open one if none. Named `tabUrl` (not `url`) because `url` is already the request URL.
- **`windowId`** (number, optional) — when the active-tab fallback is used, restrict the query to this window.
- **`background`** (boolean, optional, default `true`) — when true, do not activate the chosen tab. **Default diverges from `inject_script` (which defaults to false)** because a network call should not yank the user's focus.

## Backward compatibility

When none of these are supplied, the original active-tab behavior is preserved verbatim: same `chrome.tabs.query` shape, same error message, no focus change, no tab creation. Existing callers don't observe any behavior change.

## Use case it unlocks

Building a domain-specific MCP on top of mcp-chrome's `chrome_network_request`. Example: an OpenTable MCP wants to call OpenTable's GraphQL endpoints, which require the user's opentable.com cookies. With this PR:

```json
{
  "url": "https://www.opentable.com/dapi/fe/gql?opname=RestaurantsAvailability",
  "method": "POST",
  "headers": { "Content-Type": "application/json" },
  "body": "{...}",
  "tabUrl": "https://www.opentable.com/"
}
```

First call opens opentable.com in a background tab if none is open already, then fires the POST from there with full cookies. Subsequent calls reuse the matched tab. The user is never disturbed.

## Files touched

- `app/chrome-extension/entrypoints/background/tools/browser/network-request.ts` — adds `resolveTargetTab()` mirroring the pattern from `inject-script.ts`; threads `tabId`/`tabUrl`/`windowId`/`background` through the executor.
- `packages/shared/src/tools.ts` — adds the four new parameters to the JSON schema.
- `docs/TOOLS.md` — documents the new parameters with two examples (cross-origin + pinned tab id).

## Verification

- `pnpm build:shared` ✅
- `pnpm build:native` ✅
- `pnpm build:extension` ✅
- `npx eslint app/chrome-extension/entrypoints/background/tools/browser/network-request.ts` ✅ (clean)
- `npx prettier --check` on all touched files ✅ (clean)
- Pre-existing typecheck/lint issues in `tests/web-editor-v2/*` and a couple of Vue components are unchanged — verified by running typecheck/lint against `master` and observing the same counts (122 TS errors, 4 lint errors).

I haven't added unit tests; the project's tests directory targets `web-editor-v2` features. Happy to add network-request tests if there's a preferred location and shape — let me know.

## Note on naming

I used `tabUrl` instead of `url` for the tab-matching parameter because `url` already means "request URL" in this tool's schema. The other tab-targeting tools (`inject_script`, `web_fetcher`) overload `url` for both — that pattern doesn't extend here without collision. Open to renaming if the project prefers consistency over disambiguation.