### PR TITLE
fix: per-transport MCP server instance (prevents Already connected error)

### DIFF
--- a/app/native-server/src/mcp/mcp-server.ts
+++ b/app/native-server/src/mcp/mcp-server.ts
@@ -1,13 +1,8 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { setupTools } from './register-tools';
 
-export let mcpServer: Server | null = null;
-
-export const getMcpServer = () => {
-  if (mcpServer) {
-    return mcpServer;
-  }
-  mcpServer = new Server(
+export const createMcpServer = () => {
+  const mcpServer = new Server(
     {
       name: 'ChromeMcpServer',
       version: '1.0.0',

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -22,7 +22,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { getMcpServer } from '../mcp/mcp-server';
+import { createMcpServer } from '../mcp/mcp-server';
 import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
@@ -175,14 +175,32 @@ export class Server {
         });
 
         const transport = new SSEServerTransport('/messages', reply.raw);
+        const server = createMcpServer();
+
+        transport.onclose = () => {
+          this.transportsMap.delete(transport.sessionId);
+          server.close();
+        };
+
         this.transportsMap.set(transport.sessionId, transport);
 
         reply.raw.on('close', () => {
           this.transportsMap.delete(transport.sessionId);
+          server.close();
         });
 
-        const server = getMcpServer();
-        await server.connect(transport);
+        try {
+          await server.connect(transport);
+        } catch (error) {
+          this.transportsMap.delete(transport.sessionId);
+          server.close();
+          if (!reply.sent) {
+            reply
+              .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+              .send(ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
+          }
+          return;
+        }
 
         reply.raw.write(':\n\n');
       } catch (error) {
@@ -213,7 +231,7 @@ export class Server {
     // MCP POST endpoint
     this.fastify.post('/mcp', async (request, reply) => {
       const sessionId = request.headers['mcp-session-id'] as string | undefined;
-      let transport: StreamableHTTPServerTransport | undefined = this.transportsMap.get(
+      const transport: StreamableHTTPServerTransport | undefined = this.transportsMap.get(
         sessionId || '',
       ) as StreamableHTTPServerTransport;
 
@@ -221,21 +239,36 @@ export class Server {
         // Transport found, proceed
       } else if (!sessionId && isInitializeRequest(request.body)) {
         const newSessionId = randomUUID();
-        transport = new StreamableHTTPServerTransport({
+        const newTransport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => newSessionId,
           onsessioninitialized: (initializedSessionId) => {
-            if (transport && initializedSessionId === newSessionId) {
-              this.transportsMap.set(initializedSessionId, transport);
+            if (newTransport && initializedSessionId === newSessionId) {
+              this.transportsMap.set(initializedSessionId, newTransport);
             }
           },
         });
 
-        transport.onclose = () => {
-          if (transport?.sessionId && this.transportsMap.get(transport.sessionId)) {
-            this.transportsMap.delete(transport.sessionId);
+        const server = createMcpServer();
+
+        newTransport.onclose = () => {
+          if (newTransport?.sessionId) {
+            this.transportsMap.delete(newTransport.sessionId);
           }
+          server.close();
         };
-        await getMcpServer().connect(transport);
+
+        try {
+          await server.connect(newTransport);
+        } catch (error) {
+          if (newTransport?.sessionId) {
+            this.transportsMap.delete(newTransport.sessionId);
+          }
+          server.close();
+          reply
+            .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+            .send({ error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR });
+          return;
+        }
       } else {
         reply.code(HTTP_STATUS.BAD_REQUEST).send({ error: ERROR_MESSAGES.INVALID_MCP_REQUEST });
         return;


### PR DESCRIPTION
## Summary

Replace the singleton MCP Server with a per-transport factory pattern. This fixes the `Already connected to a transport` error when multiple clients connect or when a client reconnects after a session disconnect.

## Root Cause

The original `getMcpServer()` returned a singleton `Server` instance. The MCP SDK's `Server.connect()` only allows one transport per Server instance. When a second client (or reconnecting client) tried to connect, it threw:

> Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.

## Changes

### app/native-server/src/mcp/mcp-server.ts
- Replaced singleton `mcpServer` + `getMcpServer()` with factory function `createMcpServer()` that returns a fresh `Server` per call.

### app/native-server/src/server/index.ts
- `/sse` endpoint: per-connection `createMcpServer()` + `transport.onclose` cleanup calling `server.close()` + try/catch for connect failure.
- `/mcp POST` endpoint: renamed variable to `newTransport` (was shadowing outer `transport`), same per-connection factory + lifecycle cleanup pattern.
- Fixed `prefer-const` lint error.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Single client connect | Works | Works |
| Client reconnects | Already connected error | Works |
| Multiple simultaneous clients | Last one wins | Each gets own Server |
| Transport close | Server orphaned | server.close() called |

## Testing

Manual testing via curl to /mcp endpoint with two consecutive initialize requests confirms the fix. Build passes, lint passes.
