### PR TITLE
fix(native-server): delegate MCP SSE response ownership

### DIFF
--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -264,16 +264,11 @@ export class Server {
         return;
       }
 
-      reply.raw.setHeader('Content-Type', 'text/event-stream');
-      reply.raw.setHeader('Cache-Control', 'no-cache');
-      reply.raw.setHeader('Connection', 'keep-alive');
-      reply.raw.flushHeaders();
+      // The MCP transport owns the raw response, including SSE headers and lifecycle.
+      reply.hijack();
 
       try {
         await transport.handleRequest(request.raw, reply.raw);
-        if (!reply.sent) {
-          reply.hijack();
-        }
       } catch (error) {
         if (!reply.raw.writableEnded) {
           reply.raw.end();

--- a/app/native-server/src/server/server.test.ts
+++ b/app/native-server/src/server/server.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, test, afterAll, beforeAll } from '@jest/globals';
+import { describe, expect, test, afterAll, beforeAll, jest } from '@jest/globals';
 import supertest from 'supertest';
+import type { ServerResponse } from 'node:http';
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import Server from './index';
+
+jest.mock('../agent/engines/codex', () => ({
+  CodexEngine: jest.fn(),
+}));
+
+jest.mock('../agent/engines/claude', () => ({
+  ClaudeEngine: jest.fn(),
+}));
+
+jest.mock('../agent/db', () => ({
+  closeDb: jest.fn(),
+}));
 
 describe('服务器测试', () => {
   // 启动服务器测试实例
@@ -23,5 +37,78 @@ describe('服务器测试', () => {
       status: 'ok',
       message: 'pong',
     });
+  });
+
+  test('POST /mcp 初始化请求应只发送一次 transport 响应', async () => {
+    const response = await supertest(Server.getInstance().server)
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('Content-Type', 'application/json')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: {
+            name: 'server-test',
+            version: '1.0.0',
+          },
+        },
+      })
+      .expect(200)
+      .expect('Content-Type', /text\/event-stream/);
+
+    expect(response.headers['mcp-session-id']).toEqual(expect.any(String));
+    expect(response.text).toContain('"jsonrpc":"2.0"');
+    expect(response.text).toContain('"id":1');
+  });
+
+  test('GET /mcp 缺少 session id 时应拒绝请求', async () => {
+    const response = await supertest(Server.getInstance().server)
+      .get('/mcp')
+      .set('Accept', 'text/event-stream')
+      .expect(400)
+      .expect('Content-Type', /json/);
+
+    expect(response.body).toEqual({
+      error: 'Invalid or missing MCP session ID for SSE.',
+    });
+  });
+
+  test('GET /mcp 应由 transport 独占原始响应', async () => {
+    const sessionId = 'test-stream-session';
+    const handleRequest = jest.fn(async (_request: unknown, response: ServerResponse) => {
+      if (response.headersSent) {
+        throw new Error('Response headers were sent before the MCP transport handled the request');
+      }
+
+      response.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      response.end(': ready\n\n');
+    });
+    const serverWithTransports = Server as unknown as {
+      transportsMap: Map<string, StreamableHTTPServerTransport>;
+    };
+    serverWithTransports.transportsMap.set(sessionId, {
+      handleRequest,
+    } as unknown as StreamableHTTPServerTransport);
+
+    try {
+      const response = await supertest(Server.getInstance().server)
+        .get('/mcp')
+        .set('Accept', 'text/event-stream')
+        .set('mcp-session-id', sessionId)
+        .expect(200)
+        .expect('Content-Type', /text\/event-stream/);
+
+      expect(response.text).toBe(': ready\n\n');
+    } finally {
+      serverWithTransports.transportsMap.delete(sessionId);
+    }
   });
 });


### PR DESCRIPTION
## Root cause

The GET `/mcp` route flushed SSE headers before delegating the same raw Node response to `StreamableHTTPServerTransport`. The transport owns SSE headers and response lifecycle, so its subsequent `writeHead()` could throw `ERR_HTTP_HEADERS_SENT` during MCP connection setup.

## Changes

- hijack the Fastify reply before handing the raw response to the MCP transport
- remove the duplicate framework-side SSE header write
- add regression coverage for MCP initialization, missing sessions, and raw response ownership

## Testing

- `node_modules/.bin/jest src/server/server.test.ts --runInBand --coverage=false`
- `node_modules/.bin/prettier --check app/native-server/src/server/index.ts app/native-server/src/server/server.test.ts`
- `node_modules/.bin/eslint 'app/native-server/src/**/*.{js,ts}'`
- `node_modules/.bin/tsc -p app/native-server/tsconfig.json --noEmit`
- `npx -y pnpm@8.15.9 --filter mcp-chrome-bridge build`
- Node 22/Linux container: regression tests, TypeScript typecheck, and native-server build

Verified on Node 22/Linux at the server response boundary; a full Hermes Agent and Chrome extension end-to-end test was not run.

Closes #349
