### PR TITLE
fix(native-server): bump better-sqlite3 to ^12.1.0 for Node 24 support

### DIFF
--- a/app/native-server/package.json
+++ b/app/native-server/package.json
@@ -39,7 +39,7 @@
     "@fastify/cors": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@types/node-fetch": "2",
-    "better-sqlite3": "^11.6.0",
+    "better-sqlite3": "^12.1.0",
     "chalk": "^5.4.1",
     "chrome-devtools-frontend": "^1.0.1299282",
     "chrome-mcp-shared": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: '2'
         version: 2.6.13
       better-sqlite3:
-        specifier: ^11.6.0
-        version: 11.10.0
+        specifier: ^12.1.0
+        version: 12.11.1
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -173,7 +173,7 @@ importers:
         version: 13.1.0
       drizzle-orm:
         specifier: ^0.38.2
-        version: 0.38.4(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
+        version: 0.38.4(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       fastify:
         specifier: ^5.3.2
         version: 5.6.2
@@ -3707,8 +3707,9 @@ packages:
     hasBin: true
     dev: true
 
-  /better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  /better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -4625,7 +4626,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /drizzle-orm@0.38.4(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
+  /drizzle-orm@0.38.4(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1):
     resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -4718,7 +4719,7 @@ packages:
         optional: true
     dependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.11.1
     dev: false
 
   /dunder-proto@1.0.1:


### PR DESCRIPTION
#### Summary

Node 24(ABI 137)下 `npm i -g mcp-chrome-bridge` 安装后,扩展「智能助手」启动即报 `Could not locate the bindings file`(见 #271)

根因:`app/native-server/package.json` 将 `better-sqlite3` 锁在 `^11.6.0`,而 better-sqlite3 11.x 从未发布 Node 24 / ABI 137 的预编译二进制。安装时 `prebuild-install` 取不到预编译包,回退源码编译又因多数机器无 C++ 工具链而失败,导致 `build/Release/better_sqlite3.node` 缺失,运行时加载失败

上游已于 WiseLibs/better-sqlite3#1385 修复,12.1.0 起 release 含 Node 24 预编译。升级依赖即可让 Node 24 用户装即用

#### Changes

- `app/native-server/package.json`:`better-sqlite3` `^11.6.0` → `^12.1.0`
- `pnpm-lock.yaml`:仅更新 better-sqlite3 相关条目(解析到 `12.11.1`),保持 lockfileVersion 6.0,无无关依赖漂移

#### Compatibility

better-sqlite3 12.x 同时为 Node 20 / 22 / 24 发布预编译,对 Node 20/22 无影响。12.x 相对 11.x 无 JS API 破坏(WiseLibs/better-sqlite3#1277),仅 SQLite 引擎升级,本项目只做标准 SQL 存储

#### Testing

- 本机 Windows 11 / Node v24.18.0:`pnpm install` 后 better-sqlite3 解析到 12.11.1,预编译 `.node` 到位;加载 + 建表 + 读写冒烟通过(SQLite 3.53.2)
- mcp-chrome-bridge 进程重启稳定存活,Could not locate the bindings file 报错消失,chrome_* 工具恢复

#### Related

Closes #271
