### PR TITLE
fix(server): call reply.hijack() before StreamableHTTP handleRequest

### DIFF
--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -241,13 +241,17 @@ export class Server {
         return;
       }
 
+      reply.hijack();
       try {
         await transport.handleRequest(request.raw, reply.raw, request.body);
       } catch (error) {
-        if (!reply.sent) {
-          reply
-            .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
-            .send({ error: ERROR_MESSAGES.MCP_REQUEST_PROCESSING_ERROR });
+        if (!reply.raw.headersSent) {
+          reply.raw.writeHead(HTTP_STATUS.INTERNAL_SERVER_ERROR, {
+            'Content-Type': 'application/json',
+          });
+          reply.raw.end(
+            JSON.stringify({ error: ERROR_MESSAGES.MCP_REQUEST_PROCESSING_ERROR }),
+          );
         }
       }
     });
@@ -264,6 +268,7 @@ export class Server {
         return;
       }
 
+      reply.hijack();
       reply.raw.setHeader('Content-Type', 'text/event-stream');
       reply.raw.setHeader('Cache-Control', 'no-cache');
       reply.raw.setHeader('Connection', 'keep-alive');
@@ -271,9 +276,6 @@ export class Server {
 
       try {
         await transport.handleRequest(request.raw, reply.raw);
-        if (!reply.sent) {
-          reply.hijack();
-        }
       } catch (error) {
         if (!reply.raw.writableEnded) {
           reply.raw.end();
@@ -297,16 +299,20 @@ export class Server {
         return;
       }
 
+      reply.hijack();
       try {
         await transport.handleRequest(request.raw, reply.raw);
-        if (!reply.sent) {
-          reply.code(HTTP_STATUS.NO_CONTENT).send();
+        if (!reply.raw.writableEnded) {
+          reply.raw.end();
         }
       } catch (error) {
-        if (!reply.sent) {
-          reply
-            .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
-            .send({ error: ERROR_MESSAGES.MCP_SESSION_DELETION_ERROR });
+        if (!reply.raw.headersSent) {
+          reply.raw.writeHead(HTTP_STATUS.INTERNAL_SERVER_ERROR, {
+            'Content-Type': 'application/json',
+          });
+          reply.raw.end(
+            JSON.stringify({ error: ERROR_MESSAGES.MCP_SESSION_DELETION_ERROR }),
+          );
         }
       }
     });

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -252,6 +252,10 @@ export class Server {
           reply.raw.end(
             JSON.stringify({ error: ERROR_MESSAGES.MCP_REQUEST_PROCESSING_ERROR }),
           );
+        } else if (!reply.raw.writableEnded) {
+          // Headers already written by the SDK — nothing meaningful can be sent,
+          // but the hijacked response must still be closed or the request hangs.
+          reply.raw.end();
         }
       }
     });
@@ -313,6 +317,8 @@ export class Server {
           reply.raw.end(
             JSON.stringify({ error: ERROR_MESSAGES.MCP_SESSION_DELETION_ERROR }),
           );
+        } else if (!reply.raw.writableEnded) {
+          reply.raw.end();
         }
       }
     });


### PR DESCRIPTION
## Problem

Any MCP client using **Streamable HTTP** (e.g. OpenCode, Cursor) fails to complete the handshake against `mcp-chrome-bridge` v1.0.31. A single `initialize` POST via `curl` may return 200, but the follow-up `notifications/initialized` and the GET SSE reconnection crash the server-side stream.

Server stderr fills with:

```
Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:354:11)
    at responseViaResponseObject (.../@hono/node-server/dist/index.cjs:838:12)
    at async StreamableHTTPServerTransport.handleRequest (.../@modelcontextprotocol/sdk/dist/cjs/server/streamableHttp.js:146:9)
    at async Object.<anonymous> (.../mcp-chrome-bridge/dist/server/index.js:226:17)
```

Reported by clients (example: OpenCode 1.18.14):

```
●  ✗ chrome  failed
      SSE error: Non-200 status code (400)
      http://127.0.0.1:12306/mcp
```

(Note: the "SSE" label is misleading — OpenCode's MCP client falls back from StreamableHTTP to SSE on handshake failure and reports the last-tried transport's error.)

## Root cause

The three `/mcp` handlers in `app/native-server/src/server/index.ts` delegate to `StreamableHTTPServerTransport.handleRequest`, which writes headers and body **directly** to `reply.raw` via `@hono/node-server`'s `responseViaResponseObject`.

Fastify's own reply lifecycle is unaware of this and tries to send `reply.raw` again in the catch path (or, on GET, in the success path), throwing `ERR_HTTP_HEADERS_SENT`.

| Handler | Original bug |
|---|---|
| `POST /mcp` | Never called `reply.hijack()`. Catch path calls `reply.code(...).send(...)` → headers already written by SDK → crash. |
| `GET /mcp` | Called `reply.hijack()` **after** `handleRequest` returned (line ~274). Too late — by then headers were already written, plus an earlier `reply.raw.flushHeaders()` made the second `writeHead` inside the SDK always throw. |
| `DELETE /mcp` | Same pattern as POST — never hijacked, catch path crashes if hit. |

## Fix

Hijack `reply` **before** `transport.handleRequest(...)` on all three handlers, and rewrite the catch branches to write directly to `reply.raw` (Fastify no longer manages it after hijack):

```ts
reply.hijack();
try {
  await transport.handleRequest(request.raw, reply.raw, request.body);
} catch (error) {
  if (!reply.raw.headersSent) {
    reply.raw.writeHead(HTTP_STATUS.INTERNAL_SERVER_ERROR, {
      'Content-Type': 'application/json',
    });
    reply.raw.end(JSON.stringify({ error: ERROR_MESSAGES.MCP_REQUEST_PROCESSING_ERROR }));
  }
}
```

For GET, kept the explicit `setHeader('Content-Type', 'text/event-stream')` + `flushHeaders()` (so SSE clients see the stream headers immediately) but moved `reply.hijack()` ahead of them so Fastify leaves the response alone.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter chrome-mcp-shared build` | ✅ |
| `pnpm --filter mcp-chrome-bridge build` | ✅ `dist/server/index.js` regenerated |
| `pnpm --filter mcp-chrome-bridge lint` | ✅ clean |
| Manual MCP handshake (initialize → notifications/initialized → tools/call → delete) against patched bridge | ✅ 200 + valid `mcp-session-id` + 24 tools listed |
| Server log after patched build | ✅ zero `ERR_HTTP_HEADERS_SENT` |
| OpenCode 1.18.14 + `chrome` MCP `type: remote` | ✅ `chrome: connected`, real `get_windows_and_tabs` returns the user's 12 actual tabs |

`pnpm test` is failing on `master` independently of this change (`Cannot find module '../constant/index.js' from 'src/agent/tool-bridge.ts'` — a jest module-resolution pre-existing issue), confirmed by stashing this patch and re-running jest on baseline.

## Why this wasn't caught

- `mcp-chrome-bridge doctor` only checks `/ping`, not the `/mcp` Streamable HTTP flow.
- A naive `curl -X POST /mcp initialize` succeeds because the response is fully written before Fastify's catch path runs; the crash only manifests on multi-request handshakes or SSE reconnection.

## Related

- Affects every MCP client that uses `@modelcontextprotocol/sdk` Streamable HTTP transport, including OpenCode ≥1.17 and Cursor.
- The single-transport-per-bridge-instance design (separate concern, documented in user notes) means a crashed session also leaks a transport slot until process restart — making this bug extra painful since the bridge refuses new connections after the first failed handshake.


- Sibling PRs targeting the **lockup** side of this failure family (`Already connected to a transport` persisting after a client goes away): #338, #346, #354 (per-session transport / MCP server factory) and #365 (stale-bridge detection on `/ping`). This PR removes the *crashed-handshake* path into that lockup but does not change the single-transport design itself.
- #372 touches the same `GET /mcp` SSE response-ownership area as this PR — happy to rebase onto it or consolidate if the maintainer prefers that direction.

Fixes #378

