### PR TITLE
feat: add tab group API controls

### DIFF
--- a/app/chrome-extension/entrypoints/background/tools/browser/index.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/index.ts
@@ -1,5 +1,13 @@
 export { navigateTool, closeTabsTool, switchTabTool } from './common';
 export { windowTool } from './window';
+export {
+  listTabGroupsTool,
+  createTabGroupTool,
+  updateTabGroupTool,
+  deleteTabGroupTool,
+  moveTabGroupTool,
+  tabsGroupMembershipTool,
+} from './tab-groups';
 export { vectorSearchTabsContentTool as searchTabsContentTool } from './vector-search';
 export { screenshotTool } from './screenshot';
 export { webFetcherTool, getInteractiveElementsTool } from './web-fetcher';

--- a/app/chrome-extension/entrypoints/background/tools/browser/tab-groups.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/tab-groups.ts
@@ -1,0 +1,443 @@
+import { createErrorResponse, ToolResult } from '@/common/tool-handler';
+import { BaseBrowserToolExecutor } from '../base-browser';
+import { TOOL_NAMES } from 'chrome-mcp-shared';
+
+const GROUP_COLORS = [
+  'grey',
+  'blue',
+  'red',
+  'yellow',
+  'green',
+  'pink',
+  'purple',
+  'cyan',
+  'orange',
+] as const;
+
+type GroupColor = (typeof GROUP_COLORS)[number];
+
+const isColor = (value: unknown): value is GroupColor =>
+  typeof value === 'string' && (GROUP_COLORS as readonly string[]).includes(value);
+
+interface TabGroupSummary {
+  groupId: number;
+  windowId: number;
+  title: string;
+  color: string;
+  collapsed: boolean;
+}
+
+function serializeGroup(group: chrome.tabGroups.TabGroup): TabGroupSummary {
+  return {
+    groupId: group.id,
+    windowId: group.windowId,
+    title: group.title || '',
+    color: group.color,
+    collapsed: group.collapsed,
+  };
+}
+
+async function getGroupOrError(groupId: number): Promise<chrome.tabGroups.TabGroup> {
+  try {
+    return await chrome.tabGroups.get(groupId);
+  } catch {
+    throw new Error(`Tab group with ID ${groupId} not found`);
+  }
+}
+
+function toErrorResponse(context: string, error: unknown): ToolResult {
+  if (chrome.runtime.lastError) {
+    console.error(`Chrome API Error: ${chrome.runtime.lastError.message}`, error);
+    return createErrorResponse(`Chrome API Error: ${chrome.runtime.lastError.message}`);
+  }
+  console.error(`Error in ${context}:`, error);
+  return createErrorResponse(
+    `${context} failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
+/**
+ * Tool for listing tab groups
+ */
+class ListTabGroupsTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUPS_LIST;
+
+  async execute(args: {
+    windowId?: number;
+    title?: string;
+    color?: string;
+    collapsed?: boolean;
+    includeTabs?: boolean;
+  }): Promise<ToolResult> {
+    const { windowId, title, color, collapsed, includeTabs = true } = args ?? {};
+
+    if (color !== undefined && !isColor(color)) {
+      return createErrorResponse(
+        `Invalid color '${color}'. Valid colors: ${GROUP_COLORS.join(', ')}`,
+      );
+    }
+
+    try {
+      const queryInfo: chrome.tabGroups.QueryInfo = {};
+      if (typeof windowId === 'number') queryInfo.windowId = windowId;
+      if (title !== undefined) queryInfo.title = title;
+      if (isColor(color)) queryInfo.color = color;
+      if (typeof collapsed === 'boolean') queryInfo.collapsed = collapsed;
+
+      const groups = await chrome.tabGroups.query(queryInfo);
+
+      const includeMemberTabs =
+        includeTabs && groups.length > 0 ? await chrome.tabs.query({ windowType: 'normal' }) : [];
+
+      const result = {
+        success: true,
+        groupCount: groups.length,
+        groups: groups.map((group) => {
+          const tabs = includeMemberTabs
+            .filter((tab) => tab.groupId === group.id)
+            .map((tab) => ({
+              tabId: tab.id || 0,
+              url: tab.url || '',
+              title: tab.title || '',
+              active: tab.active || false,
+            }));
+          return {
+            ...serializeGroup(group),
+            tabCount: tabs.length,
+            ...(includeTabs ? { tabs } : {}),
+          };
+        }),
+      };
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('ListTabGroupsTool.execute', error);
+    }
+  }
+}
+
+/**
+ * Tool for creating a tab group
+ */
+class CreateTabGroupTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_CREATE;
+
+  async execute(args: {
+    tabIds?: number[];
+    windowId?: number;
+    title?: string;
+    color?: string;
+    collapsed?: boolean;
+  }): Promise<ToolResult> {
+    const { tabIds, windowId, title, color, collapsed } = args ?? {};
+
+    if (color !== undefined && !isColor(color)) {
+      return createErrorResponse(
+        `Invalid color '${color}'. Valid colors: ${GROUP_COLORS.join(', ')}`,
+      );
+    }
+
+    const hasTabIds = Array.isArray(tabIds) && tabIds.length > 0;
+    if (!hasTabIds && typeof windowId !== 'number') {
+      return createErrorResponse(
+        'Either tabIds or windowId is required: provide tabIds to group existing tabs, or windowId to create a new group seeded with a blank tab.',
+      );
+    }
+
+    try {
+      let groupId: number;
+      let seedTabId: number | undefined;
+
+      if (hasTabIds) {
+        const createProperties: { windowId?: number } = {};
+        if (typeof windowId === 'number') createProperties.windowId = windowId;
+        groupId = await chrome.tabs.group({
+          tabIds: tabIds as number[],
+          createProperties,
+        });
+      } else {
+        const targetWindowId =
+          typeof windowId === 'number' ? windowId : (await chrome.windows.getLastFocused()).id;
+        const seedTab = await chrome.tabs.create({
+          windowId: targetWindowId,
+          active: false,
+          url: 'about:blank',
+        });
+        seedTabId = seedTab.id;
+        groupId = await chrome.tabs.group({
+          tabIds: [seedTab.id as number],
+        });
+      }
+
+      const updateOptions: chrome.tabGroups.UpdateProperties = {};
+      if (title !== undefined) updateOptions.title = title;
+      if (isColor(color)) updateOptions.color = color;
+      if (typeof collapsed === 'boolean') updateOptions.collapsed = collapsed;
+      if (Object.keys(updateOptions).length > 0) {
+        await chrome.tabGroups.update(groupId, updateOptions);
+      }
+
+      const updatedGroup = await getGroupOrError(groupId);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Successfully created tab group${title ? ` '${title}'` : ''}`,
+              ...serializeGroup(updatedGroup),
+              ...(seedTabId !== undefined ? { seedTabId } : {}),
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('CreateTabGroupTool.execute', error);
+    }
+  }
+}
+
+/**
+ * Tool for updating a tab group (rename, recolor, collapse/expand)
+ */
+class UpdateTabGroupTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_UPDATE;
+
+  async execute(args: {
+    groupId: number;
+    title?: string;
+    color?: string;
+    collapsed?: boolean;
+  }): Promise<ToolResult> {
+    const { groupId, title, color, collapsed } = args ?? {};
+
+    if (typeof groupId !== 'number') {
+      return createErrorResponse('groupId parameter is required and must be a number');
+    }
+    if (title === undefined && color === undefined && collapsed === undefined) {
+      return createErrorResponse(
+        'At least one of title, color, or collapsed must be provided to update the group',
+      );
+    }
+    if (color !== undefined && !isColor(color)) {
+      return createErrorResponse(
+        `Invalid color '${color}'. Valid colors: ${GROUP_COLORS.join(', ')}`,
+      );
+    }
+
+    try {
+      await getGroupOrError(groupId);
+
+      const updateProperties: chrome.tabGroups.UpdateProperties = {};
+      if (title !== undefined) updateProperties.title = title;
+      if (isColor(color)) updateProperties.color = color;
+      if (typeof collapsed === 'boolean') updateProperties.collapsed = collapsed;
+
+      await chrome.tabGroups.update(groupId, updateProperties);
+      const updatedGroup = await getGroupOrError(groupId);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Successfully updated tab group ID: ${groupId}`,
+              ...serializeGroup(updatedGroup),
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('UpdateTabGroupTool.execute', error);
+    }
+  }
+}
+
+/**
+ * Tool for deleting a tab group (ungroup its tabs or close them)
+ */
+class DeleteTabGroupTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_DELETE;
+
+  async execute(args: { groupId: number; closeTabs?: boolean }): Promise<ToolResult> {
+    const { groupId, closeTabs = false } = args ?? {};
+
+    if (typeof groupId !== 'number') {
+      return createErrorResponse('groupId parameter is required and must be a number');
+    }
+
+    try {
+      const group = await getGroupOrError(groupId);
+      const memberTabs = await chrome.tabs.query({ groupId });
+
+      if (memberTabs.length === 0) {
+        return createErrorResponse(`Tab group ID ${groupId} has no member tabs`);
+      }
+
+      const tabIds = memberTabs.map((tab) => tab.id as number);
+
+      if (closeTabs) {
+        await chrome.tabs.remove(tabIds);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Successfully closed tab group '${group.title}' (ID: ${groupId}) and its ${tabIds.length} tab(s)`,
+                groupId,
+                closedTabIds: tabIds,
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+
+      await chrome.tabs.ungroup(tabIds);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Successfully deleted tab group '${group.title}' (ID: ${groupId}); ${tabIds.length} tab(s) remain open`,
+              groupId,
+              ungroupedTabIds: tabIds,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('DeleteTabGroupTool.execute', error);
+    }
+  }
+}
+
+/**
+ * Tool for moving a whole tab group within its window or to another window
+ */
+class MoveTabGroupTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TAB_GROUP_MOVE;
+
+  async execute(args: { groupId: number; index?: number; windowId?: number }): Promise<ToolResult> {
+    const { groupId, index, windowId } = args ?? {};
+
+    if (typeof groupId !== 'number') {
+      return createErrorResponse('groupId parameter is required and must be a number');
+    }
+    if (index === undefined && windowId === undefined) {
+      return createErrorResponse(
+        'At least one of index or windowId must be provided to move the group',
+      );
+    }
+
+    try {
+      await getGroupOrError(groupId);
+
+      const moveProperties: chrome.tabGroups.MoveProperties = {
+        index: typeof index === 'number' ? index : -1,
+      };
+      if (typeof windowId === 'number') moveProperties.windowId = windowId;
+
+      await chrome.tabGroups.move(groupId, moveProperties);
+      const movedGroup = await getGroupOrError(groupId);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Successfully moved tab group ID: ${groupId}`,
+              ...serializeGroup(movedGroup),
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('MoveTabGroupTool.execute', error);
+    }
+  }
+}
+
+/**
+ * Tool for managing tab membership in tab groups (add/remove tabs)
+ */
+class TabsGroupMembershipTool extends BaseBrowserToolExecutor {
+  name = TOOL_NAMES.BROWSER.TABS_GROUP_MEMBERSHIP;
+
+  async execute(args: {
+    action: 'add' | 'remove';
+    tabIds: number[];
+    groupId?: number;
+  }): Promise<ToolResult> {
+    const { action, tabIds, groupId } = args ?? {};
+
+    if (action !== 'add' && action !== 'remove') {
+      return createErrorResponse("action parameter is required and must be 'add' or 'remove'");
+    }
+    if (!Array.isArray(tabIds) || tabIds.length === 0) {
+      return createErrorResponse(
+        'tabIds parameter is required and must be a non-empty array of numbers',
+      );
+    }
+    if (action === 'add' && typeof groupId !== 'number') {
+      return createErrorResponse("groupId parameter is required when action is 'add'");
+    }
+
+    try {
+      if (action === 'add') {
+        const group = await getGroupOrError(groupId as number);
+        await chrome.tabs.group({ tabIds, groupId });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Successfully added ${tabIds.length} tab(s) to group '${group.title}' (ID: ${groupId})`,
+                groupId,
+                tabIds,
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+
+      await chrome.tabs.ungroup(tabIds);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Successfully removed ${tabIds.length} tab(s) from their group(s)`,
+              tabIds,
+            }),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      return toErrorResponse('TabsGroupMembershipTool.execute', error);
+    }
+  }
+}
+
+export const listTabGroupsTool = new ListTabGroupsTool();
+export const createTabGroupTool = new CreateTabGroupTool();
+export const updateTabGroupTool = new UpdateTabGroupTool();
+export const deleteTabGroupTool = new DeleteTabGroupTool();
+export const moveTabGroupTool = new MoveTabGroupTool();
+export const tabsGroupMembershipTool = new TabsGroupMembershipTool();

--- a/app/chrome-extension/entrypoints/background/tools/browser/window.ts
+++ b/app/chrome-extension/entrypoints/background/tools/browser/window.ts
@@ -9,15 +9,32 @@ class WindowTool extends BaseBrowserToolExecutor {
       const windows = await chrome.windows.getAll({ populate: true });
       let tabCount = 0;
 
+      const allTabs = windows.flatMap((window) => window.tabs || []);
+      const groupedTabs = allTabs.filter(
+        (tab) => typeof tab.groupId === 'number' && tab.groupId !== -1,
+      );
+      const groups =
+        groupedTabs.length > 0
+          ? await chrome.tabGroups.query({}).catch(() => [] as chrome.tabGroups.TabGroup[])
+          : ([] as chrome.tabGroups.TabGroup[]);
+      const groupsById = new Map(groups.map((group) => [group.id, group]));
+
       const structuredWindows = windows.map((window) => {
         const tabs =
           window.tabs?.map((tab) => {
             tabCount++;
+            const group =
+              typeof tab.groupId === 'number' && tab.groupId !== -1
+                ? groupsById.get(tab.groupId)
+                : undefined;
             return {
               tabId: tab.id || 0,
               url: tab.url || '',
               title: tab.title || '',
               active: tab.active || false,
+              ...(group
+                ? { groupId: group.id, groupTitle: group.title || '', groupColor: group.color }
+                : {}),
             };
           }) || [];
 

--- a/app/chrome-extension/wxt.config.ts
+++ b/app/chrome-extension/wxt.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     permissions: [
       'nativeMessaging',
       'tabs',
+      'tabGroups',
       'activeTab',
       'scripting',
       'contextMenus',

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -34,13 +34,18 @@ List all currently open browser windows and tabs.
           "tabId": 456,
           "url": "https://example.com",
           "title": "Example Page",
-          "active": true
+          "active": true,
+          "groupId": 789,
+          "groupTitle": "Work",
+          "groupColor": "blue"
         }
       ]
     }
   ]
 }
 ```
+
+Tabs that belong to a tab group include `groupId`, `groupTitle` and `groupColor`; ungrouped tabs omit these fields.
 
 ### `chrome_navigate`
 
@@ -99,6 +104,128 @@ Switch to a specific browser tab.
 {
   "tabId": 456,
   "windowId": 123
+}
+```
+
+### `chrome_list_tab_groups`
+
+List tab groups, optionally including their member tabs.
+
+**Parameters**:
+
+- `windowId` (number, optional): Only list groups in this window
+- `title` (string, optional): Only list groups with exactly this title
+- `color` (string, optional): Filter by color (`grey`, `blue`, `red`, `yellow`, `green`, `pink`, `purple`, `cyan`, `orange`)
+- `collapsed` (boolean, optional): Filter by collapsed state
+- `includeTabs` (boolean, optional): Include each group's member tabs in the result (default: true)
+
+**Example**:
+
+```json
+{
+  "windowId": 123,
+  "includeTabs": true
+}
+```
+
+### `chrome_create_tab_group`
+
+Create a tab group from existing tabs, or create a new group seeded with a blank tab.
+
+**Parameters**:
+
+- `tabIds` (array, optional): Existing tab IDs to put into the new group (must be in the same window)
+- `windowId` (number, optional): Window for the new group. Required when `tabIds` is omitted; a blank seed tab is created as the first member of the group
+- `title` (string, optional): Title of the new group
+- `color` (string, optional): Color of the new group
+- `collapsed` (boolean, optional): Whether the group starts collapsed
+
+**Example**:
+
+```json
+{
+  "tabIds": [456, 789],
+  "title": "Research",
+  "color": "green"
+}
+```
+
+### `chrome_update_tab_group`
+
+Rename a tab group, change its color, or collapse/expand it.
+
+**Parameters**:
+
+- `groupId` (number, required): The ID of the tab group to update
+- `title` (string, optional): New title
+- `color` (string, optional): New color
+- `collapsed` (boolean, optional): Collapse/expand the group
+
+**Example**:
+
+```json
+{
+  "groupId": 789,
+  "title": "Deep Work",
+  "color": "purple"
+}
+```
+
+### `chrome_delete_tab_group`
+
+Delete a tab group. By default the tabs are ungrouped but stay open; set `closeTabs` to true to close all tabs in the group instead.
+
+**Parameters**:
+
+- `groupId` (number, required): The ID of the tab group to delete
+- `closeTabs` (boolean, optional): Close all tabs in the group instead of ungrouping them (default: false)
+
+**Example**:
+
+```json
+{
+  "groupId": 789,
+  "closeTabs": false
+}
+```
+
+### `chrome_move_tab_group`
+
+Move a whole tab group: reorder it within its window or move it to another window.
+
+**Parameters**:
+
+- `groupId` (number, required): The ID of the tab group to move
+- `index` (number, optional): Tab index to move the group to within the target window (`-1` for the end)
+- `windowId` (number, optional): Move the group to this window
+
+**Example**:
+
+```json
+{
+  "groupId": 789,
+  "windowId": 123,
+  "index": -1
+}
+```
+
+### `chrome_tabs_group_membership`
+
+Add tabs to an existing tab group, or remove (ungroup) tabs from their groups.
+
+**Parameters**:
+
+- `action` (string, required): `"add"` puts the tabs into the given group; `"remove"` ungroups the tabs
+- `tabIds` (array, required): Tab IDs. For `"add"`, all tabs must already be in the same window as the target group
+- `groupId` (number, optional/required): Target group ID. Required when `action` is `"add"`
+
+**Example**:
+
+```json
+{
+  "action": "add",
+  "tabIds": [101, 102],
+  "groupId": 789
 }
 ```
 

--- a/docs/TOOLS_zh.md
+++ b/docs/TOOLS_zh.md
@@ -34,13 +34,18 @@
           "tabId": 456,
           "url": "https://example.com",
           "title": "示例页面",
-          "active": true
+          "active": true,
+          "groupId": 789,
+          "groupTitle": "工作",
+          "groupColor": "blue"
         }
       ]
     }
   ]
 }
 ```
+
+属于标签组的标签页会包含 `groupId`、`groupTitle` 和 `groupColor` 字段；未分组的标签页则不包含这些字段。
 
 ### `chrome_navigate`
 
@@ -97,6 +102,128 @@
 {
   "tabId": 456,
   "windowId": 123
+}
+```
+
+### `chrome_list_tab_groups`
+
+列出标签组，可选择包含组内的标签页。
+
+**参数**：
+
+- `windowId` (数字，可选)：仅列出该窗口中的标签组
+- `title` (字符串，可选)：仅列出具有该标题的标签组
+- `color` (字符串，可选)：按颜色筛选（`grey`、`blue`、`red`、`yellow`、`green`、`pink`、`purple`、`cyan`、`orange`）
+- `collapsed` (布尔值，可选)：按折叠状态筛选
+- `includeTabs` (布尔值，可选)：在结果中包含每个组的成员标签页（默认：true）
+
+**示例**：
+
+```json
+{
+  "windowId": 123,
+  "includeTabs": true
+}
+```
+
+### `chrome_create_tab_group`
+
+从现有标签页创建标签组，或创建一个以空白标签页作为首个成员的新标签组。
+
+**参数**：
+
+- `tabIds` (数组，可选)：要放入新标签组的现有标签页 ID（必须位于同一窗口）
+- `windowId` (数字，可选)：新标签组所在的窗口。省略 `tabIds` 时必需；此时会创建一个空白种子标签页作为该组的第一个成员
+- `title` (字符串，可选)：新标签组的标题
+- `color` (字符串，可选)：新标签组的颜色
+- `collapsed` (布尔值，可选)：新标签组是否初始折叠
+
+**示例**：
+
+```json
+{
+  "tabIds": [456, 789],
+  "title": "调研",
+  "color": "green"
+}
+```
+
+### `chrome_update_tab_group`
+
+重命名标签组、更改其颜色或折叠/展开它。
+
+**参数**：
+
+- `groupId` (数字，必需)：要更新的标签组 ID
+- `title` (字符串，可选)：新标题
+- `color` (字符串，可选)：新颜色
+- `collapsed` (布尔值，可选)：折叠/展开标签组
+
+**示例**：
+
+```json
+{
+  "groupId": 789,
+  "title": "深度工作",
+  "color": "purple"
+}
+```
+
+### `chrome_delete_tab_group`
+
+删除标签组。默认情况下组内标签页会被移出分组但保持打开；将 `closeTabs` 设为 true 则关闭组内所有标签页。
+
+**参数**：
+
+- `groupId` (数字，必需)：要删除的标签组 ID
+- `closeTabs` (布尔值，可选)：关闭组内所有标签页而不是将其移出分组（默认：false）
+
+**示例**：
+
+```json
+{
+  "groupId": 789,
+  "closeTabs": false
+}
+```
+
+### `chrome_move_tab_group`
+
+移动整个标签组：在其所在窗口内重新排序，或移动到其他窗口。
+
+**参数**：
+
+- `groupId` (数字，必需)：要移动的标签组 ID
+- `index` (数字，可选)：目标窗口内的标签页索引（`-1` 表示末尾）
+- `windowId` (数字，可选)：将标签组移动到该窗口
+
+**示例**：
+
+```json
+{
+  "groupId": 789,
+  "windowId": 123,
+  "index": -1
+}
+```
+
+### `chrome_tabs_group_membership`
+
+将标签页添加到现有标签组，或将标签页从所属标签组中移除。
+
+**参数**：
+
+- `action` (字符串，必需)：`"add"` 将标签页加入指定标签组；`"remove"` 将标签页移出分组
+- `tabIds` (数组，必需)：标签页 ID。使用 `"add"` 时，所有标签页必须已位于目标标签组所在的窗口中
+- `groupId` (数字，可选/必需)：目标标签组 ID。当 `action` 为 `"add"` 时必需
+
+**示例**：
+
+```json
+{
+  "action": "add",
+  "tabIds": [101, 102],
+  "groupId": 789
 }
 ```
 

--- a/packages/shared/src/tools.ts
+++ b/packages/shared/src/tools.ts
@@ -8,6 +8,12 @@ export const TOOL_NAMES = {
     SCREENSHOT: 'chrome_screenshot',
     CLOSE_TABS: 'chrome_close_tabs',
     SWITCH_TAB: 'chrome_switch_tab',
+    TAB_GROUPS_LIST: 'chrome_list_tab_groups',
+    TAB_GROUP_CREATE: 'chrome_create_tab_group',
+    TAB_GROUP_UPDATE: 'chrome_update_tab_group',
+    TAB_GROUP_DELETE: 'chrome_delete_tab_group',
+    TAB_GROUP_MOVE: 'chrome_move_tab_group',
+    TABS_GROUP_MEMBERSHIP: 'chrome_tabs_group_membership',
     WEB_FETCHER: 'chrome_get_web_content',
     CLICK: 'chrome_click_element',
     FILL: 'chrome_fill_or_select',
@@ -521,6 +527,169 @@ export const TOOL_SCHEMAS: Tool[] = [
         },
       },
       required: ['tabId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUPS_LIST,
+    description: 'List tab groups in the browser, optionally including their member tabs',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        windowId: {
+          type: 'number',
+          description: 'Only list groups in this window. If omitted, lists groups in all windows.',
+        },
+        title: {
+          type: 'string',
+          description: 'Only list groups with exactly this title.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'Only list groups with this color.',
+        },
+        collapsed: {
+          type: 'boolean',
+          description: 'Only list groups matching this collapsed state.',
+        },
+        includeTabs: {
+          type: 'boolean',
+          description:
+            'Include the member tabs (tabId, url, title, active) of each group in the result (default: true).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_CREATE,
+    description:
+      'Create a tab group from existing tabs, or create a new group seeded with a blank tab. Optionally set title, color and collapsed state.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabIds: {
+          type: 'array',
+          items: { type: 'number' },
+          description:
+            'Array of existing tab IDs to put into the new group. All tabs must be in the same window.',
+        },
+        windowId: {
+          type: 'number',
+          description:
+            'Window where the group is created. Required when tabIds is omitted (a blank seed tab will be created as the first member of the group). Ignored when tabIds is provided.',
+        },
+        title: {
+          type: 'string',
+          description: 'Title of the new group.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'Color of the new group.',
+        },
+        collapsed: {
+          type: 'boolean',
+          description: 'Whether the group should start collapsed (default: false).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_UPDATE,
+    description: 'Update a tab group: rename it, change its color, or collapse/expand it',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the tab group to update.',
+        },
+        title: {
+          type: 'string',
+          description: 'New title for the group.',
+        },
+        color: {
+          type: 'string',
+          enum: ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'],
+          description: 'New color for the group.',
+        },
+        collapsed: {
+          type: 'boolean',
+          description: 'Whether the group should be collapsed.',
+        },
+      },
+      required: ['groupId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_DELETE,
+    description:
+      'Delete a tab group. By default the tabs are ungrouped but stay open; set closeTabs to true to close all tabs in the group instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the tab group to delete.',
+        },
+        closeTabs: {
+          type: 'boolean',
+          description:
+            'Close all tabs in the group instead of ungrouping them (default: false = keep tabs open).',
+        },
+      },
+      required: ['groupId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TAB_GROUP_MOVE,
+    description:
+      'Move a whole tab group: reorder it within its window or move it to another window',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        groupId: {
+          type: 'number',
+          description: 'The ID of the tab group to move.',
+        },
+        index: {
+          type: 'number',
+          description:
+            'Tab index to move the group to within the target window. Use -1 for the end.',
+        },
+        windowId: {
+          type: 'number',
+          description: 'Move the group to this window. If omitted, the group stays in its window.',
+        },
+      },
+      required: ['groupId'],
+    },
+  },
+  {
+    name: TOOL_NAMES.BROWSER.TABS_GROUP_MEMBERSHIP,
+    description: 'Add tabs to an existing tab group, or remove (ungroup) tabs from their groups',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['add', 'remove'],
+          description: "'add' puts the tabs into the given group; 'remove' ungroups the tabs.",
+        },
+        tabIds: {
+          type: 'array',
+          items: { type: 'number' },
+          description:
+            "Array of tab IDs. For 'add', all tabs must already be in the same window as the target group.",
+        },
+        groupId: {
+          type: 'number',
+          description: "Target group ID. Required when action is 'add'.",
+        },
+      },
+      required: ['action', 'tabIds'],
     },
   },
   {


### PR DESCRIPTION
## Summary

Adds MCP tool support for controlling Chrome tab groups, as requested in #171.

New `tab-groups.ts` module exposing tools to:
- Create, update (rename/recolor), and close tab groups
- Add or remove tabs from a group
- List existing tab groups with their properties
- Ungroup tabs

Also updates the shared tool definitions (`packages/shared/src/tools.ts`), registers the new tools in the background service worker, adds the required `tabGroups` permission in `wxt.config.ts`, and documents all new tools in both `docs/TOOLS.md` and `docs/TOOLS_zh.md`.

## Testing

- Local smoke test passed against a running Chromium instance (group create/rename/recolor/add/remove/list/ungroup/close)

Closes #171