### PR TITLE
fix(native-server): per-session MCP Server and correct SSE header handling

### DIFF
--- a/app/native-server/src/mcp/mcp-server.ts
+++ b/app/native-server/src/mcp/mcp-server.ts
@@ -22,3 +22,27 @@ export const getMcpServer = () => {
   setupTools(mcpServer);
   return mcpServer;
 };
+
+/**
+ * Build a fresh Server bound to a single transport.
+ *
+ * An SDK `Server` can only be connected to one transport at a time, so sharing
+ * the `getMcpServer()` singleton across sessions makes every connection after
+ * the first fail with "Already connected to a transport".
+ */
+export const createMcpServer = () => {
+  const server = new Server(
+    {
+      name: 'ChromeMcpServer',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  setupTools(server);
+  return server;
+};

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -22,7 +22,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'node:crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { getMcpServer } from '../mcp/mcp-server';
+import { createMcpServer } from '../mcp/mcp-server';
 import { AgentStreamManager } from '../agent/stream-manager';
 import { AgentChatService } from '../agent/chat-service';
 import { CodexEngine } from '../agent/engines/codex';
@@ -181,7 +181,10 @@ export class Server {
           this.transportsMap.delete(transport.sessionId);
         });
 
-        const server = getMcpServer();
+        const server = createMcpServer();
+        transport.onclose = () => {
+          void server.close();
+        };
         await server.connect(transport);
 
         reply.raw.write(':\n\n');
@@ -230,12 +233,14 @@ export class Server {
           },
         });
 
+        const sessionServer = createMcpServer();
         transport.onclose = () => {
           if (transport?.sessionId && this.transportsMap.get(transport.sessionId)) {
             this.transportsMap.delete(transport.sessionId);
           }
+          void sessionServer.close();
         };
-        await getMcpServer().connect(transport);
+        await sessionServer.connect(transport);
       } else {
         reply.code(HTTP_STATUS.BAD_REQUEST).send({ error: ERROR_MESSAGES.INVALID_MCP_REQUEST });
         return;
@@ -264,16 +269,13 @@ export class Server {
         return;
       }
 
-      reply.raw.setHeader('Content-Type', 'text/event-stream');
-      reply.raw.setHeader('Cache-Control', 'no-cache');
-      reply.raw.setHeader('Connection', 'keep-alive');
-      reply.raw.flushHeaders();
+      // Hand the socket to the transport before anything is written to it.
+      // Pre-flushing SSE headers here makes the SDK's own writeHead() throw
+      // ERR_HTTP_HEADERS_SENT, which kills the stream on every connect.
+      reply.hijack();
 
       try {
         await transport.handleRequest(request.raw, reply.raw);
-        if (!reply.sent) {
-          reply.hijack();
-        }
       } catch (error) {
         if (!reply.raw.writableEnded) {
           reply.raw.end();


### PR DESCRIPTION
Fixes three related bugs in the native server that make the HTTP transport unusable with more than one client and break the SSE stream on every connect.

Closes #321, #345, #349, #378.

### 1. `Server` singleton breaks every session after the first

`getMcpServer()` returns a process-wide instance, but an SDK `Server` can only be bound to one transport at a time. The second client to connect fails with `Already connected to a transport`, so opening a second MCP session kills the first.

Adds a `createMcpServer()` factory and uses it at both `connect()` sites, so each session gets its own instance.

### 2. Session servers were never closed

`transport.onclose` now closes that session's `Server` on both the legacy SSE and streamable HTTP paths, so disconnecting clients no longer leak one.

### 3. `GET /mcp` pre-flushes SSE headers, killing the stream

The handler set the SSE headers and called `flushHeaders()` before `transport.handleRequest()`. The SDK transport then calls `writeHead()` itself and throws `ERR_HTTP_HEADERS_SENT`, so the stream dies on every connect.

Replaced with `reply.hijack()`, handing the socket to the transport before anything is written to it.

### Notes

- `getMcpServer()` is left exported for compatibility, though nothing in the native server uses it now.
- Two files changed, no dependency or API changes.

### Testing

`tsc --noEmit` on `app/native-server` reports an identical set of 19 pre-existing diagnostics before and after this change, none of them in the two touched files.

The equivalent changes have been running against the published 1.0.31 build in daily use since 25 August, across repeated reconnects and concurrent sessions.