### PR TITLE
fix(native-server): close CORS origin bypass in HTTP API (CSWSH/CSRF)

### DIFF
--- a/app/native-server/src/server/cors-origin.ts
+++ b/app/native-server/src/server/cors-origin.ts
@@ -1,0 +1,52 @@
+/**
+ * CORS origin validation for the native server's HTTP API.
+ *
+ * Split out of server/index.ts so it can be unit tested without pulling in
+ * that file's much heavier dependency graph (MCP transports, agent engines,
+ * db, ...).
+ */
+
+/**
+ * Checks a request's `Origin` header against SERVER_CONFIG.CORS_ORIGIN.
+ *
+ * String entries in the allowlist (e.g. `'http://127.0.0.1'`) used to be
+ * matched with `origin.startsWith(pattern)`, which is a substring match, not
+ * an origin match: `http://127.0.0.1.evil.com` (a domain an attacker fully
+ * controls, registered under their own zone) satisfies
+ * `startsWith('http://127.0.0.1')` even though it shares no host with
+ * 127.0.0.1. Verified live: with `credentials: true` also set on the CORS
+ * plugin, that origin got `access-control-allow-origin` reflected back and
+ * `access-control-allow-credentials: true`, so any site hosted at such a
+ * domain could drive this server's full MCP surface (browser automation -
+ * navigation, script execution, cookies, screenshots) from any tab, with no
+ * user interaction beyond visiting the page.
+ *
+ * String entries are now compared as an origin (scheme + hostname, matching
+ * any port, since the existing entries never specify one) via the WHATWG URL
+ * parser instead of a raw string prefix, closing that off. RegExp entries
+ * (used for `chrome-extension://`/`moz-extension://`) are unaffected.
+ */
+export function isOriginAllowed(origin: string, patterns: readonly (string | RegExp)[]): boolean {
+  let parsedOrigin: URL;
+  try {
+    parsedOrigin = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  return patterns.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(origin);
+    }
+    let parsedPattern: URL;
+    try {
+      parsedPattern = new URL(pattern);
+    } catch {
+      return false;
+    }
+    return (
+      parsedOrigin.protocol === parsedPattern.protocol &&
+      parsedOrigin.hostname === parsedPattern.hostname
+    );
+  });
+}

--- a/app/native-server/src/server/cors.test.ts
+++ b/app/native-server/src/server/cors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+import { isOriginAllowed } from './cors-origin';
+import { SERVER_CONFIG } from '../constant';
+
+describe('isOriginAllowed', () => {
+  test('allows the exact configured origin', () => {
+    expect(isOriginAllowed('http://127.0.0.1', SERVER_CONFIG.CORS_ORIGIN)).toBe(true);
+  });
+
+  test('allows the configured origin on any port', () => {
+    expect(isOriginAllowed('http://127.0.0.1:5173', SERVER_CONFIG.CORS_ORIGIN)).toBe(true);
+  });
+
+  test('allows a chrome-extension origin', () => {
+    expect(
+      isOriginAllowed(
+        'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+        SERVER_CONFIG.CORS_ORIGIN,
+      ),
+    ).toBe(true);
+  });
+
+  // Regression test: SERVER_CONFIG.CORS_ORIGIN's 'http://127.0.0.1' string
+  // entry used to be matched with origin.startsWith(pattern), a substring
+  // match rather than an origin match. Verified live against the actual
+  // @fastify/cors plugin with this exact config: this origin got
+  // access-control-allow-origin reflected back with
+  // access-control-allow-credentials: true, i.e. any page hosted at a
+  // domain an attacker fully controls (they own evil.com and can create
+  // any subdomain under it, including this one) could make credentialed
+  // cross-origin requests to the native server's full MCP surface.
+  test('rejects an attacker-controlled domain that merely starts with the allowed string', () => {
+    expect(isOriginAllowed('http://127.0.0.1.evil.com', SERVER_CONFIG.CORS_ORIGIN)).toBe(false);
+  });
+
+  test('rejects an attacker-controlled domain with the allowed string as a path segment', () => {
+    expect(isOriginAllowed('http://evil.com/http://127.0.0.1', SERVER_CONFIG.CORS_ORIGIN)).toBe(
+      false,
+    );
+  });
+
+  test('rejects a different scheme against the same host', () => {
+    expect(isOriginAllowed('https://127.0.0.1', SERVER_CONFIG.CORS_ORIGIN)).toBe(false);
+  });
+
+  test('rejects an unrelated origin', () => {
+    expect(isOriginAllowed('http://attacker.example', SERVER_CONFIG.CORS_ORIGIN)).toBe(false);
+  });
+
+  test('rejects a malformed origin instead of throwing', () => {
+    expect(isOriginAllowed('not-a-url', SERVER_CONFIG.CORS_ORIGIN)).toBe(false);
+  });
+});

--- a/app/native-server/src/server/index.ts
+++ b/app/native-server/src/server/index.ts
@@ -29,6 +29,7 @@ import { CodexEngine } from '../agent/engines/codex';
 import { ClaudeEngine } from '../agent/engines/claude';
 import { closeDb } from '../agent/db';
 import { registerAgentRoutes } from './routes';
+import { isOriginAllowed } from './cors-origin';
 
 // ============================================================
 // Types
@@ -76,11 +77,7 @@ export class Server {
         if (!origin) {
           return cb(null, true);
         }
-        // Check if origin matches any pattern in whitelist
-        const allowed = SERVER_CONFIG.CORS_ORIGIN.some((pattern) =>
-          pattern instanceof RegExp ? pattern.test(origin) : origin.startsWith(pattern),
-        );
-        cb(null, allowed);
+        cb(null, isOriginAllowed(origin, SERVER_CONFIG.CORS_ORIGIN));
       },
       methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
       credentials: true,


### PR DESCRIPTION
See the linked issue for the full report.

## Root cause

`setupPlugins()` (`app/native-server/src/server/index.ts`) registers `@fastify/cors` with `credentials: true` and matches string entries in `SERVER_CONFIG.CORS_ORIGIN` with `origin.startsWith(pattern)`. The `'http://127.0.0.1'` entry is a substring match, not an origin match: a domain an attacker fully controls (they own the zone and can create any subdomain under it) such as `http://127.0.0.1.evil.com` satisfies `startsWith('http://127.0.0.1')` even though it shares no host with `127.0.0.1`.

Verified live against the actual `@fastify/cors` plugin with this exact config: a request with `Origin: http://127.0.0.1.evil.com` got `access-control-allow-origin: http://127.0.0.1.evil.com` and `access-control-allow-credentials: true` back. Since `/mcp` is the MCP protocol endpoint itself, any web page hosted at such a domain can speak MCP directly to this server from any open tab, with no interaction beyond visiting the page, and drive whatever browser-automation tools this server exposes.

## Fix

- Extracted the origin check into its own `isOriginAllowed()` (`server/cors-origin.ts`, kept out of `server/index.ts` so it's testable without pulling in that file's much larger dependency graph).
- String allowlist entries are now parsed and compared as an origin (protocol + hostname, matching any port since none of the existing entries specify one) via the WHATWG `URL` parser instead of a raw string prefix.
- `RegExp` entries (`chrome-extension://`, `moz-extension://`) are unchanged.

## Testing

- `cors.test.ts`: 8 cases, including the exact malicious-origin PoC asserted as rejected, a path-segment variant, a scheme-mismatch case, and a malformed-origin case (must return `false`, not throw).
- Confirmed the malicious-origin test fails against the pre-fix `startsWith` logic and passes against the fix (swapped the implementation back temporarily, reran, restored the fix).
- `npx tsc --noEmit` and `npx eslint` clean on all three changed files.